### PR TITLE
feat: Elastic report storage and multisensor support in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,3 +84,27 @@ All notable changes to the Cowrie Processor script will be documented in this fi
 - File download/upload tracking
 - Abnormal attack detection
 - Report generation 
+## [Unreleased]
+### Added
+- Central SQLite database support with per-sensor tagging via `--sensor` and `--db` (tables now include `hostname`).
+- SQLite runtime tuning for central DB (WAL mode, `busy_timeout=5000`).
+- Elasticsearch write via ILM write aliases in `es_reports.py` (daily/weekly/monthly `*-write`).
+- ILM policies guidance updated to keep indices forever (no delete): daily hot 7d -> cold, weekly hot 30d -> cold, monthly hot 90d -> cold.
+- Per-sensor and aggregate daily reports; weekly and monthly rollups from daily docs.
+- Orchestration script `orchestrate_sensors.py` with TOML config (`sensors.example.toml`).
+- Environment variable `ES_VERIFY_SSL=false` support in `es_reports.py`.
+- Requirements updated: `elasticsearch>=8,<9` and `tomli` (for Python <3.11).
+- API robustness in `process_cowrie.py`: HTTP timeouts, retries with backoff, and per-service rate limiting; `indicator_cache` table with TTLs for hashes/IPs to reduce API load.
+- Refresh utility `refresh_cache_and_reports.py` to renew indicator cache and reindex recent daily/weekly/monthly reports within hot windows.
+
+### Changed
+- README documentation expanded: central DB usage, ES reporting, write aliases, and orchestration.
+- Deployment guidance references write aliases for ILM consistency.
+ - ILM policies updated to never delete; daily hot 7d -> cold, weekly hot 30d -> cold, monthly hot 90d -> cold.
+
+### Notes
+- Historical merge is not required; rebuild from retained raw logs is recommended.
+- For concurrent writers, stagger processor runs slightly to minimize DB locks.
+
+### Removed
+- Deprecated `reports_index_template.json` in favor of per-type index templates and write aliases.

--- a/deployment_configs.md
+++ b/deployment_configs.md
@@ -1,0 +1,369 @@
+# Deployment Configuration for Cowrie Reports
+
+## 1. Elasticsearch ILM Policies (no delete)
+
+Create three policies that never delete, only age to cold:
+
+```json
+PUT _ilm/policy/cowrie.reports.daily
+{
+  "policy": {
+    "phases": {
+      "hot": {"min_age": "0ms", "actions": {"set_priority": {"priority": 100}}},
+      "cold": {"min_age": "7d", "actions": {"set_priority": {"priority": 0}}}
+    }
+  }
+}
+
+PUT _ilm/policy/cowrie.reports.weekly
+{
+  "policy": {
+    "phases": {
+      "hot": {"min_age": "0ms", "actions": {"set_priority": {"priority": 100}}},
+      "cold": {"min_age": "30d", "actions": {"set_priority": {"priority": 0}}}
+    }
+  }
+}
+
+PUT _ilm/policy/cowrie.reports.monthly
+{
+  "policy": {
+    "phases": {
+      "hot": {"min_age": "0ms", "actions": {"set_priority": {"priority": 100}}},
+      "cold": {"min_age": "90d", "actions": {"set_priority": {"priority": 0}}}
+    }
+  }
+}
+```
+
+## 2. Bootstrap Indices
+
+```bash
+# Create index templates (daily/weekly/monthly)
+curl -X PUT "localhost:9200/_index_template/cowrie.reports.daily" \
+  -H "Content-Type: application/json" \
+  -d @scripts/cowrie.reports.daily-index.json
+
+curl -X PUT "localhost:9200/_index_template/cowrie.reports.weekly" \
+  -H "Content-Type: application/json" \
+  -d @scripts/cowrie.reports.weekly-index.json
+
+curl -X PUT "localhost:9200/_index_template/cowrie.reports.monthly" \
+  -H "Content-Type: application/json" \
+  -d @scripts/cowrie.reports.monthly-index.json
+
+# Create initial indices with write aliases
+curl -X PUT "localhost:9200/cowrie.reports.daily-000001" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "aliases": {
+      "cowrie.reports.daily-write": {}
+    }
+  }'
+
+curl -X PUT "localhost:9200/cowrie.reports.weekly-000001" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "aliases": {
+      "cowrie.reports.weekly-write": {}
+    }
+  }'
+
+curl -X PUT "localhost:9200/cowrie.reports.monthly-000001" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "aliases": {
+      "cowrie.reports.monthly-write": {}
+    }
+  }'
+```
+
+## 3. Systemd Timer Configuration
+
+### `/etc/systemd/system/cowrie-reports-daily.service`
+
+```ini
+[Unit]
+Description=Generate Cowrie Daily Reports for Elasticsearch
+After=network.target elasticsearch.service
+
+[Service]
+Type=oneshot
+User=cowrie
+Group=cowrie
+WorkingDirectory=/home/cowrie/dshield
+Environment="ES_HOST=localhost:9200"
+Environment="ES_USERNAME=elastic"
+Environment="ES_PASSWORD=changeme"
+ExecStart=/usr/bin/python3 /home/cowrie/dshield/es_reports.py daily --all-sensors
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### `/etc/systemd/system/cowrie-reports-daily.timer`
+
+```ini
+[Unit]
+Description=Run Cowrie Daily Reports at 04:30 UTC
+Requires=cowrie-reports-daily.service
+
+[Timer]
+OnCalendar=04:30
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+### `/etc/systemd/system/cowrie-reports-weekly.service`
+
+```ini
+[Unit]
+Description=Generate Cowrie Weekly Reports for Elasticsearch
+After=network.target elasticsearch.service
+
+[Service]
+Type=oneshot
+User=cowrie
+Group=cowrie
+WorkingDirectory=/home/cowrie/dshield
+Environment="ES_HOST=localhost:9200"
+Environment="ES_USERNAME=elastic"
+Environment="ES_PASSWORD=changeme"
+ExecStart=/usr/bin/python3 /home/cowrie/dshield/es_reports.py weekly
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### `/etc/systemd/system/cowrie-reports-weekly.timer`
+
+```ini
+[Unit]
+Description=Run Cowrie Weekly Reports on Mondays at 05:00 UTC
+Requires=cowrie-reports-weekly.service
+
+[Timer]
+OnCalendar=Mon *-*-* 05:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+### Enable the timers:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable cowrie-reports-daily.timer
+sudo systemctl enable cowrie-reports-weekly.timer
+sudo systemctl start cowrie-reports-daily.timer
+sudo systemctl start cowrie-reports-weekly.timer
+
+# Check timer status
+sudo systemctl list-timers | grep cowrie
+```
+
+## 4. Alternative: Cron Configuration
+
+If you prefer cron over systemd:
+
+```bash
+# Edit crontab for cowrie user
+crontab -e
+
+# Add these lines:
+# Daily reports at 04:30 UTC
+30 4 * * * cd /home/cowrie/dshield && python3 es_reports.py daily --all-sensors >> /var/log/cowrie-reports.log 2>&1
+
+# Weekly reports on Mondays at 05:00 UTC
+0 5 * * 1 cd /home/cowrie/dshield && python3 es_reports.py weekly >> /var/log/cowrie-reports.log 2>&1
+
+# Monthly reports on 1st of month at 05:30 UTC
+30 5 1 * * cd /home/cowrie/dshield && python3 es_reports.py monthly >> /var/log/cowrie-reports.log 2>&1
+```
+
+## 5. Environment Variables Configuration
+
+Create `/home/cowrie/dshield/.env`:
+
+```bash
+# Elasticsearch Configuration
+ES_HOST=localhost:9200
+ES_USERNAME=elastic
+ES_PASSWORD=your_secure_password
+# Or use API key instead:
+# ES_API_KEY=your_api_key_here
+
+# Or for Elastic Cloud:
+# ES_CLOUD_ID=your_cloud_id
+# ES_API_KEY=your_cloud_api_key
+
+# Optional: Disable SSL verification for self-signed certs
+# ES_VERIFY_SSL=false
+
+# Report Configuration
+TOP_N=10
+VT_RECENT_DAYS=5
+```
+
+## 6. Testing Commands
+
+```bash
+# Test daily report generation (dry run - just prints)
+python3 es_reports.py daily --date 2024-12-20
+
+# Generate report for specific sensor
+python3 es_reports.py daily --sensor honeypot1 --date 2024-12-20
+
+# Backfill last 7 days
+python3 es_reports.py backfill --start 2024-12-14 --end 2024-12-20
+
+# Generate weekly rollup
+python3 es_reports.py weekly --week 2024-W51
+
+# Check if reports are being indexed
+curl -X GET "localhost:9200/cowrie.reports.daily-*/_search?size=1&pretty"
+```
+
+## 7. Kibana Dashboard Queries
+
+Example queries for visualizations:
+
+### Daily Session Trend
+```json
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"report_type": "daily"}},
+        {"term": {"sensor": "aggregate"}},
+        {"range": {"date_utc": {"gte": "now-30d"}}}
+      ]
+    }
+  },
+  "aggs": {
+    "sessions_over_time": {
+      "date_histogram": {
+        "field": "date_utc",
+        "calendar_interval": "day"
+      },
+      "aggs": {
+        "total_sessions": {
+          "sum": {"field": "sessions.total"}
+        }
+      }
+    }
+  }
+}
+```
+
+### Alert Monitor
+```json
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {"nested": {
+          "path": "alerts",
+          "query": {
+            "term": {"alerts.severity": "high"}
+          }
+        }},
+        {"range": {"date_utc": {"gte": "now-7d"}}}
+      ]
+    }
+  }
+}
+```
+
+## 8. Monitoring & Alerting
+
+### Watcher Alert for High Severity Alerts
+```json
+PUT _watcher/watch/cowrie_high_severity_alert
+{
+  "trigger": {
+    "schedule": {"interval": "5m"}
+  },
+  "input": {
+    "search": {
+      "request": {
+        "indices": ["cowrie.reports.daily-*"],
+        "body": {
+          "query": {
+            "bool": {
+              "filter": [
+                {"range": {"@timestamp": {"gte": "now-5m"}}},
+                {"nested": {
+                  "path": "alerts",
+                  "query": {
+                    "term": {"alerts.severity": "high"}
+                  }
+                }}
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "condition": {
+    "compare": {"ctx.payload.hits.total": {"gt": 0}}
+  },
+  "actions": {
+    "send_email": {
+      "email": {
+        "to": "security@example.com",
+        "subject": "Cowrie High Severity Alert",
+        "body": "New high severity alerts detected in Cowrie reports"
+      }
+    }
+  }
+}
+```
+
+## 9. Requirements Update
+
+Add to `requirements.txt`:
+```
+elasticsearch>=8.0.0,<9.0.0
+```
+
+## 10. Backup Strategy
+
+```bash
+# Daily backup of SQLite database (add to cron)
+0 3 * * * sqlite3 /home/cowrie/cowrieprocessor.sqlite ".backup /backup/cowrie/cowrieprocessor-$(date +\%Y\%m\%d).sqlite"
+
+# Elasticsearch snapshot repository setup
+PUT _snapshot/cowrie_backup
+{
+  "type": "fs",
+  "settings": {
+    "location": "/backup/elasticsearch/cowrie"
+  }
+}
+
+# Create snapshot policy
+PUT _slm/policy/cowrie-reports-backup
+{
+  "schedule": "0 0 2 * * ?",
+  "name": "<cowrie-reports-{now/d}>",
+  "repository": "cowrie_backup",
+  "config": {
+    "indices": ["cowrie.reports.*"],
+    "include_global_state": false
+  },
+  "retention": {
+    "expire_after": "30d",
+    "min_count": 7,
+    "max_count": 30
+  }
+}
+```

--- a/es_reports.py
+++ b/es_reports.py
@@ -1,0 +1,995 @@
+#!/usr/bin/env python3
+"""Generate and index daily/weekly/monthly reports from Cowrie data to Elasticsearch.
+
+This tool reads from the SQLite database populated by process_cowrie.py and generates
+aggregated reports for Elasticsearch, supporting multi-sensor deployments.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+from elasticsearch import Elasticsearch
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class CowrieReporter:
+    """Generate Elasticsearch reports from Cowrie SQLite data."""
+    
+    def __init__(
+        self,
+        db_path: str = "../cowrieprocessor.sqlite",
+        es_host: Optional[str] = None,
+        es_username: Optional[str] = None,
+        es_password: Optional[str] = None,
+        es_api_key: Optional[str] = None,
+        es_cloud_id: Optional[str] = None,
+        es_verify_ssl: bool = True,
+        sensor_name: Optional[str] = None,
+        top_n: int = 10,
+        vt_recent_days: int = 5,
+        timezone_str: str = "UTC"
+    ):
+        """Initialize reporter with database and Elasticsearch connections.
+        
+        Args:
+            db_path: Path to SQLite database
+            es_host: Elasticsearch host URL
+            es_username: Basic auth username
+            es_password: Basic auth password
+            es_api_key: API key for authentication
+            es_cloud_id: Elastic Cloud ID
+            es_verify_ssl: Verify SSL certificates
+            sensor_name: Override sensor name (default: hostname)
+            top_n: Number of top items to include in reports
+            vt_recent_days: Days to consider VT submission "recent"
+            timezone_str: Timezone for date boundaries (default: UTC)
+        """
+        self.db_path = db_path
+        self.top_n = top_n
+        self.vt_recent_days = vt_recent_days
+        self.timezone = timezone_str
+        self.sensor_name = sensor_name or os.uname().nodename
+        
+        # Connect to SQLite
+        self.conn = sqlite3.connect(db_path)
+        self.conn.row_factory = sqlite3.Row
+        try:
+            self.conn.execute('PRAGMA busy_timeout=5000')
+        except Exception:
+            pass
+        
+        # Connect to Elasticsearch
+        es_config: Dict[str, Any] = {}
+        if es_cloud_id:
+            es_config['cloud_id'] = es_cloud_id
+        elif es_host:
+            es_config['hosts'] = [es_host]
+        else:
+            raise ValueError("Either es_host or es_cloud_id must be provided")
+            
+        if es_api_key:
+            es_config['api_key'] = es_api_key
+        elif es_username and es_password:
+            es_config['basic_auth'] = (es_username, es_password)
+        
+        es_config['verify_certs'] = es_verify_ssl
+        
+        self.es = Elasticsearch(**es_config)
+        
+        # Verify connection
+        if not self.es.ping():
+            raise ConnectionError("Cannot connect to Elasticsearch")
+            
+        logger.info("Connected to Elasticsearch and SQLite database")
+        
+    def _get_top_n(self, items: List[Any], n: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Get top N items with counts from a list."""
+        if not items:
+            return []
+        n = n or self.top_n
+        counter = Counter(items)
+        return [{"value": k, "count": v} for k, v in counter.most_common(n)]
+    
+    def _get_date_range(self, date_utc: str) -> Tuple[int, int]:
+        """Convert date string to epoch timestamps for day boundaries."""
+        dt = datetime.strptime(date_utc, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        start_epoch = int(dt.timestamp())
+        end_epoch = int((dt + timedelta(days=1)).timestamp())
+        return start_epoch, end_epoch
+    
+    def generate_daily_report(self, date_utc: str, sensor: Optional[str] = None) -> Dict[str, Any]:
+        """Generate daily report for a specific sensor or aggregate.
+        
+        Args:
+            date_utc: Date in YYYY-MM-DD format
+            sensor: Specific sensor name, or None for aggregate
+            
+        Returns:
+            Report document ready for indexing
+        """
+        start_epoch, end_epoch = self._get_date_range(date_utc)
+        
+        # Build sensor filter
+        sensor_filter = ""
+        params: List[Any] = [start_epoch, end_epoch]
+        if sensor:
+            sensor_filter = " AND hostname = ?"
+            params.append(sensor)
+        
+        # Initialize report structure
+        report: Dict[str, Any] = {
+            "@timestamp": datetime.utcnow().isoformat() + "Z",
+            "date_utc": date_utc,
+            "sensor": sensor or "aggregate",
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "report_type": "daily",
+            "sessions": {},
+            "commands": {},
+            "files": {},
+            "enrichments": {},
+            "abnormalities": {},
+            "alerts": []
+        }
+        
+        # Query sessions
+        cur = self.conn.cursor()
+        
+        # Basic session metrics
+        query = f"""
+            SELECT 
+                COUNT(DISTINCT session) as total_sessions,
+                COUNT(DISTINCT source_ip) as unique_ips,
+                COUNT(DISTINCT username) as unique_usernames,
+                COUNT(DISTINCT password) as unique_passwords,
+                AVG(total_commands) as avg_commands,
+                MAX(total_commands) as max_commands,
+                MIN(total_commands) as min_commands,
+                AVG(session_duration) as avg_duration
+            FROM sessions 
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+        """
+        
+        cur.execute(query, tuple(params))
+        row = cur.fetchone()
+        
+        report['sessions'] = {
+            'total': row['total_sessions'] or 0,
+            'unique_ips': row['unique_ips'] or 0,
+            'unique_usernames': row['unique_usernames'] or 0,
+            'unique_passwords': row['unique_passwords'] or 0,
+            'avg_commands': round(row['avg_commands'] or 0, 2),
+            'max_commands': row['max_commands'] or 0,
+            'min_commands': row['min_commands'] or 0,
+            'avg_duration': round(row['avg_duration'] or 0, 2)
+        }
+        
+        # Protocol breakdown
+        query = f"""
+            SELECT protocol, COUNT(*) as count
+            FROM sessions
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+            GROUP BY protocol
+        """
+        cur.execute(query, tuple(params))
+        protocols: Dict[str, int] = {}
+        for row in cur.fetchall():
+            if row['protocol']:
+                protocols[row['protocol']] = row['count']
+        report['sessions']['protocols'] = protocols
+        
+        # Top usernames, passwords, and combinations
+        query = f"""
+            SELECT username, COUNT(*) as count
+            FROM sessions
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+            GROUP BY username
+            ORDER BY count DESC
+            LIMIT ?
+        """
+        cur.execute(query, (*tuple(params), self.top_n))
+        report['sessions']['top_usernames'] = [
+            {"value": row['username'], "count": row['count']} 
+            for row in cur.fetchall() if row['username']
+        ]
+        
+        query = f"""
+            SELECT password, COUNT(*) as count
+            FROM sessions
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+            GROUP BY password
+            ORDER BY count DESC
+            LIMIT ?
+        """
+        cur.execute(query, (*tuple(params), self.top_n))
+        report['sessions']['top_passwords'] = [
+            {"value": row['password'], "count": row['count']}
+            for row in cur.fetchall() if row['password']
+        ]
+        
+        query = f"""
+            SELECT username || ':' || password as combo, COUNT(*) as count
+            FROM sessions
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+            GROUP BY username, password
+            ORDER BY count DESC
+            LIMIT ?
+        """
+        cur.execute(query, (*tuple(params), self.top_n))
+        report['sessions']['top_combinations'] = [
+            {"value": row['combo'], "count": row['count']}
+            for row in cur.fetchall() if row['combo']
+        ]
+        
+        # Command statistics
+        query = f"""
+            SELECT 
+                COUNT(*) as total_commands,
+                COUNT(DISTINCT command) as unique_commands
+            FROM commands c
+            JOIN sessions s ON c.session = s.session
+            WHERE s.timestamp >= ? AND s.timestamp < ?{(' AND s.hostname = ?' if sensor else '')}
+        """
+        cur.execute(query, tuple(params))
+        row = cur.fetchone()
+        
+        report['commands'] = {
+            'total': row['total_commands'] or 0,
+            'unique': row['unique_commands'] or 0
+        }
+        
+        # Top commands
+        query = f"""
+            SELECT command, COUNT(*) as count
+            FROM commands c
+            JOIN sessions s ON c.session = s.session
+            WHERE s.timestamp >= ? AND s.timestamp < ?{(' AND s.hostname = ?' if sensor else '')}
+            GROUP BY command
+            ORDER BY count DESC
+            LIMIT ?
+        """
+        cur.execute(query, (*tuple(params), self.top_n))
+        report['commands']['top_commands'] = [
+            {"value": row['command'], "count": row['count']}
+            for row in cur.fetchall() if row['command']
+        ]
+        
+        # File activity
+        query = f"""
+            SELECT 
+                COUNT(CASE WHEN transfer_method = 'DOWNLOAD' THEN 1 END) as downloads,
+                COUNT(CASE WHEN transfer_method = 'UPLOAD' THEN 1 END) as uploads,
+                COUNT(DISTINCT hash) as unique_hashes,
+                COUNT(DISTINCT vt_threat_classification) as unique_vt_classifications
+            FROM files f
+            JOIN sessions s ON f.session = s.session
+            WHERE s.timestamp >= ? AND s.timestamp < ?{(' AND s.hostname = ?' if sensor else '')}
+        """
+        cur.execute(query, tuple(params))
+        row = cur.fetchone()
+        
+        report['files'] = {
+            'downloads_total': row['downloads'] or 0,
+            'uploads_total': row['uploads'] or 0,
+            'unique_hashes': row['unique_hashes'] or 0,
+            'unique_vt_classifications': row['unique_vt_classifications'] or 0
+        }
+        
+        # VT classifications breakdown
+        query = f"""
+            SELECT vt_threat_classification, COUNT(*) as count
+            FROM files f
+            JOIN sessions s ON f.session = s.session
+            WHERE s.timestamp >= ? AND s.timestamp < ?{(' AND s.hostname = ?' if sensor else '')}
+            AND vt_threat_classification IS NOT NULL
+            GROUP BY vt_threat_classification
+            ORDER BY count DESC
+            LIMIT ?
+        """
+        cur.execute(query, (*tuple(params), self.top_n))
+        report['files']['vt_classifications_top'] = [
+            {"value": row['vt_threat_classification'], "count": row['count']}
+            for row in cur.fetchall() if row['vt_threat_classification']
+        ]
+        
+        # Recent VT submissions
+        recent_cutoff = int((datetime.utcnow() - timedelta(days=self.vt_recent_days)).timestamp())
+        query = """
+            SELECT COUNT(DISTINCT f.session) as recent_sessions
+            FROM files f
+            JOIN sessions s ON f.session = s.session
+            WHERE s.timestamp >= ? AND s.timestamp < ?
+            AND f.vt_first_submission >= ?
+        """
+        cur.execute(query, (*tuple(params), recent_cutoff))
+        row = cur.fetchone()
+        report['files']['recent_vt_submissions'] = row['recent_sessions'] or 0
+        
+        # Top file hashes
+        query = f"""
+            SELECT hash, COUNT(*) as count
+            FROM files f
+            JOIN sessions s ON f.session = s.session
+            WHERE s.timestamp >= ? AND s.timestamp < ?{(' AND s.hostname = ?' if sensor else '')}
+            GROUP BY hash
+            ORDER BY count DESC
+            LIMIT ?
+        """
+        cur.execute(query, (*tuple(params), self.top_n))
+        report['files']['top_hashes'] = [
+            {"value": row['hash'][:16] + "...", "count": row['count']}
+            for row in cur.fetchall() if row['hash']
+        ]
+        
+        # Enrichment data (URLhaus, ASN, Country, SPUR)
+        
+        # URLhaus tags
+        query = f"""
+            SELECT urlhaus_tag
+            FROM sessions
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+            AND urlhaus_tag IS NOT NULL AND urlhaus_tag != ''
+        """
+        cur.execute(query, tuple(params))
+        all_tags: List[str] = []
+        for row in cur.fetchall():
+            if row['urlhaus_tag']:
+                all_tags.extend([t.strip() for t in row['urlhaus_tag'].split(',')])
+        report['enrichments']['urlhaus_tags_top'] = self._get_top_n(all_tags)
+        
+        # Top ASNs
+        query = f"""
+            SELECT asname, COUNT(*) as count
+            FROM sessions
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+            AND asname IS NOT NULL
+            GROUP BY asname
+            ORDER BY count DESC
+            LIMIT ?
+        """
+        cur.execute(query, (*tuple(params), self.top_n))
+        report['enrichments']['asn_top'] = [
+            {"value": row['asname'], "count": row['count']}
+            for row in cur.fetchall() if row['asname']
+        ]
+        
+        # Top countries
+        query = f"""
+            SELECT ascountry, COUNT(*) as count
+            FROM sessions
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+            AND ascountry IS NOT NULL
+            GROUP BY ascountry
+            ORDER BY count DESC
+            LIMIT ?
+        """
+        cur.execute(query, (*tuple(params), self.top_n))
+        report['enrichments']['country_top'] = [
+            {"value": row['ascountry'], "count": row['count']}
+            for row in cur.fetchall() if row['ascountry']
+        ]
+        
+        # SPUR infrastructure types
+        query = f"""
+            SELECT spur_infrastructure, COUNT(*) as count
+            FROM sessions
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+            AND spur_infrastructure IS NOT NULL AND spur_infrastructure != ''
+            GROUP BY spur_infrastructure
+            ORDER BY count DESC
+            LIMIT ?
+        """
+        cur.execute(query, (*tuple(params), self.top_n))
+        report['enrichments']['spur_infrastructure_top'] = [
+            {"value": row['spur_infrastructure'], "count": row['count']}
+            for row in cur.fetchall() if row['spur_infrastructure']
+        ]
+        
+        # SPUR tunnel usage
+        query = f"""
+            SELECT 
+                COUNT(CASE WHEN spur_tunnel_type IS NOT NULL AND spur_tunnel_type != '' THEN 1 END) as tunnel_sessions,
+                COUNT(CASE WHEN spur_tunnel_anonymous = 'true' THEN 1 END) as anonymous_tunnels
+            FROM sessions
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+        """
+        cur.execute(query, tuple(params))
+        row = cur.fetchone()
+        report['enrichments']['spur_tunnels'] = {
+            'total': row['tunnel_sessions'] or 0,
+            'anonymous': row['anonymous_tunnels'] or 0
+        }
+        
+        # Abnormality detection (based on process_cowrie.py logic)
+        
+        # Get command count distribution for anomaly detection
+        query = f"""
+            SELECT total_commands, COUNT(*) as session_count
+            FROM sessions
+            WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+            GROUP BY total_commands
+            ORDER BY session_count DESC
+        """
+        cur.execute(query, tuple(params))
+        command_distribution = list(cur.fetchall())
+        
+        if command_distribution:
+            # Find uncommon command counts (bottom 2/3 by frequency)
+            sorted_counts = sorted(command_distribution, key=lambda x: x['session_count'])
+            threshold_idx = int(len(sorted_counts) * 2/3)
+            uncommon_counts = set(row['total_commands'] for row in sorted_counts[:threshold_idx])
+            
+            # Count sessions with uncommon command counts
+            query = f"""
+                SELECT COUNT(DISTINCT session) as count
+                FROM sessions
+                WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+                AND total_commands IN ({','.join('?' * len(uncommon_counts))})
+            """
+            if uncommon_counts:
+                cur.execute(query, (*tuple(params), *uncommon_counts))
+                row = cur.fetchone()
+                report['abnormalities']['uncommon_command_sessions'] = row['count'] or 0
+            else:
+                report['abnormalities']['uncommon_command_sessions'] = 0
+        else:
+            report['abnormalities']['uncommon_command_sessions'] = 0
+            
+        # Sessions with recent VT submissions
+        report['abnormalities']['recent_vt_submission_sessions'] = report['files']['recent_vt_submissions']
+        
+        # Alert generation
+        alerts: List[Dict[str, Any]] = []
+        
+        # Alert: Spike in unique IPs (>50% increase from 7-day average)
+        week_ago = (datetime.strptime(date_utc, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
+        query = f"""
+            SELECT AVG(ip_count) as avg_ips FROM (
+                SELECT COUNT(DISTINCT source_ip) as ip_count
+                FROM sessions
+                WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
+                GROUP BY timestamp / 86400
+            )
+        """
+        week_start, _ = self._get_date_range(week_ago)
+        cur.execute(query, (week_start, start_epoch, *([sensor] if sensor else [])))
+        row = cur.fetchone()
+        avg_ips = row['avg_ips'] or 0
+        
+        if avg_ips > 0 and report['sessions']['unique_ips'] > avg_ips * 1.5:
+            pct_increase = int((report['sessions']['unique_ips'] / avg_ips - 1) * 100)
+            msg = f"Unique IPs increased by {pct_increase}% from 7-day average"
+            alerts.append({
+                "type": "ip_spike",
+                "severity": "medium",
+                "message": msg,
+                "current": report['sessions']['unique_ips'],
+                "average": round(avg_ips, 2)
+            })
+        
+        # Alert: New VT classification not seen in past 30 days
+        if report['files']['vt_classifications_top']:
+            month_ago = (datetime.strptime(date_utc, "%Y-%m-%d") - timedelta(days=30)).strftime("%Y-%m-%d")
+            month_start, _ = self._get_date_range(month_ago)
+            
+            query = f"""
+                SELECT DISTINCT vt_threat_classification
+                FROM files f
+                JOIN sessions s ON f.session = s.session
+                WHERE s.timestamp >= ? AND s.timestamp < ?{(' AND s.hostname = ?' if sensor else '')}
+                AND vt_threat_classification IS NOT NULL
+            """
+            cur.execute(query, (month_start, start_epoch, *( [sensor] if sensor else [])))
+            past_classifications = set(row['vt_threat_classification'] for row in cur.fetchall())
+            
+            cur.execute(query, tuple(params))
+            today_classifications = set(row['vt_threat_classification'] for row in cur.fetchall())
+            
+            new_classifications = today_classifications - past_classifications
+            if new_classifications:
+                alerts.append({
+                    "type": "new_vt_classification",
+                    "severity": "high",
+                    "message": f"New VT classifications detected: {', '.join(new_classifications)}",
+                    "classifications": list(new_classifications)
+                })
+        
+        # Alert: High percentage of tunneled traffic
+        if report['sessions']['total'] > 0:
+            tunnel_pct = (report['enrichments']['spur_tunnels']['total'] / report['sessions']['total']) * 100
+            if tunnel_pct > 30:  # More than 30% tunneled
+                alerts.append({
+                    "type": "high_tunnel_usage",
+                    "severity": "medium",
+                    "message": f"{tunnel_pct:.1f}% of sessions using tunnels/proxies",
+                    "percentage": round(tunnel_pct, 2)
+                })
+        
+        report['alerts'] = alerts
+        
+        cur.close()
+        return report
+    
+    def index_report(self, report: Dict[str, Any], index_pattern: str = "cowrie.reports.daily-write") -> bool:
+        """Index a report document to Elasticsearch.
+        
+        Args:
+            report: Report document
+            index_pattern: Index pattern to use
+            
+        Returns:
+            Success status
+        """
+        # Always write to the ILM write alias. If a base name was provided, append -write.
+        index_alias = index_pattern if index_pattern.endswith('-write') else f"{index_pattern}-write"
+        doc_id = f"{report['sensor']}:{report['date_utc']}"
+        
+        try:
+            self.es.index(
+                index=index_alias,
+                id=doc_id,
+                document=report
+            )
+            logger.info(f"Indexed report {doc_id} to {index_alias}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to index report {doc_id}: {e}")
+            return False
+    
+    def backfill_daily(self, start_date: str, end_date: str, sensors: Optional[List[str]] = None) -> None:
+        """Backfill daily reports for a date range.
+        
+        Args:
+            start_date: Start date (YYYY-MM-DD)
+            end_date: End date (YYYY-MM-DD), inclusive
+            sensors: List of sensors to process (None for all)
+        """
+        # Get list of sensors if not provided
+        if not sensors:
+            cur = self.conn.cursor()
+            cur.execute("SELECT DISTINCT hostname FROM sessions WHERE hostname IS NOT NULL")
+            sensors = [row['hostname'] for row in cur.fetchall()]
+            cur.close()
+            
+        # Always include aggregate
+        sensors_to_process: List[Optional[str]] = [*sensors, None]
+        
+        # Iterate through dates
+        current = datetime.strptime(start_date, "%Y-%m-%d")
+        end = datetime.strptime(end_date, "%Y-%m-%d")
+        
+        total_reports = 0
+        failed_reports = 0
+        
+        while current <= end:
+            date_str = current.strftime("%Y-%m-%d")
+            logger.info(f"Processing {date_str}")
+            
+            for sensor in sensors_to_process:
+                sensor_name = sensor or "aggregate"
+                try:
+                    report = self.generate_daily_report(date_str, sensor)
+                    if self.index_report(report):
+                        total_reports += 1
+                    else:
+                        failed_reports += 1
+                except Exception as e:
+                    logger.error(f"Failed to generate report for {sensor_name} on {date_str}: {e}")
+                    failed_reports += 1
+                    
+            current += timedelta(days=1)
+            
+        logger.info(f"Backfill complete: {total_reports} indexed, {failed_reports} failed")
+    
+    def generate_weekly_rollup(self, year_week: str) -> Optional[Dict[str, Any]]:
+        """Generate weekly rollup from daily reports.
+        
+        Args:
+            year_week: Year and week in YYYY-Www format
+            
+        Returns:
+            Weekly rollup document
+        """
+        # Parse year and week
+        year_s, week_s = year_week.split('-W')
+        year_i = int(year_s)
+        week_i = int(week_s)
+        
+        # Calculate date range for the week
+        jan1 = datetime(year_i, 1, 1)
+        week_start = jan1 + timedelta(days=(week_i - 1) * 7 - jan1.weekday())
+        week_end = week_start + timedelta(days=6)
+        
+        # Query daily reports from Elasticsearch
+        query = {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"range": {"date_utc": {
+                            "gte": week_start.strftime("%Y-%m-%d"),
+                            "lte": week_end.strftime("%Y-%m-%d")
+                        }}},
+                        {"term": {"report_type": "daily"}},
+                        {"term": {"sensor": "aggregate"}}
+                    ]
+                }
+            },
+            "size": 7
+        }
+        
+        response = self.es.search(
+            index="cowrie.reports.daily-*",
+            body=query
+        )
+        
+        if not response['hits']['hits']:
+            logger.warning(f"No daily reports found for week {year_week}")
+            return None
+            
+        # Aggregate the daily reports
+        weekly: Dict[str, Any] = {
+            "@timestamp": datetime.utcnow().isoformat() + "Z",
+            "year_week": year_week,
+            "date_range": {
+                "start": week_start.strftime("%Y-%m-%d"),
+                "end": week_end.strftime("%Y-%m-%d")
+            },
+            "sensor": "aggregate",
+            "report_type": "weekly",
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "days_included": len(response['hits']['hits']),
+            "sessions": defaultdict(int),
+            "commands": defaultdict(int),
+            "files": defaultdict(int),
+            "enrichments": defaultdict(list),
+            "alerts_summary": []
+        }
+        
+        # Sum up metrics from daily reports
+        for hit in response['hits']['hits']:
+            daily = cast(Dict[str, Any], hit['_source'])
+            
+            # Aggregate sessions
+            for key in ['total', 'unique_ips', 'unique_usernames', 'unique_passwords']:
+                if key in daily.get('sessions', {}):
+                    weekly['sessions'][key] += daily['sessions'][key]
+                    
+            # Aggregate commands
+            for key in ['total', 'unique']:
+                if key in daily.get('commands', {}):
+                    weekly['commands'][key] += daily['commands'][key]
+                    
+            # Aggregate files
+            for key in ['downloads_total', 'uploads_total', 'unique_hashes']:
+                if key in daily.get('files', {}):
+                    weekly['files'][key] += daily['files'][key]
+                    
+            # Collect all alerts
+            if daily.get('alerts'):
+                weekly['alerts_summary'].extend(daily['alerts'])
+                
+        # Convert defaultdicts to regular dicts
+        weekly['sessions'] = dict(weekly['sessions'])
+        weekly['commands'] = dict(weekly['commands'])
+        weekly['files'] = dict(weekly['files'])
+        
+        # Calculate averages
+        if weekly['days_included'] > 0:
+            weekly['sessions']['daily_average'] = round(
+                weekly['sessions']['total'] / weekly['days_included'], 2
+            )
+            weekly['commands']['daily_average'] = round(
+                weekly['commands']['total'] / weekly['days_included'], 2
+            )
+            
+        return weekly
+    
+    def generate_monthly_rollup(self, year_month: str) -> Optional[Dict[str, Any]]:
+        """Generate monthly rollup from daily reports.
+        
+        Args:
+            year_month: Year and month in YYYY-MM format
+        Returns:
+            Monthly rollup document or None if no data
+        """
+        year, month = map(int, year_month.split('-'))
+        month_start = datetime(year, month, 1)
+        if month == 12:
+            month_end = datetime(year + 1, 1, 1) - timedelta(days=1)
+        else:
+            month_end = datetime(year, month + 1, 1) - timedelta(days=1)
+
+        query = {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"range": {"date_utc": {
+                            "gte": month_start.strftime("%Y-%m-%d"),
+                            "lte": month_end.strftime("%Y-%m-%d")
+                        }}},
+                        {"term": {"report_type": "daily"}},
+                        {"term": {"sensor": "aggregate"}}
+                    ]
+                }
+            },
+            "size": 31
+        }
+
+        response = self.es.search(index="cowrie.reports.daily-*", body=query)
+        hits = response.get('hits', {}).get('hits', [])
+        if not hits:
+            logger.warning(f"No daily reports found for month {year_month}")
+            return None
+
+        monthly: Dict[str, Any] = {
+            "@timestamp": datetime.utcnow().isoformat() + "Z",
+            "year_month": year_month,
+            "date_range": {
+                "start": month_start.strftime("%Y-%m-%d"),
+                "end": month_end.strftime("%Y-%m-%d")
+            },
+            "sensor": "aggregate",
+            "report_type": "monthly",
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "days_included": len(hits),
+            "sessions": defaultdict(int),
+            "commands": defaultdict(int),
+            "files": defaultdict(int),
+            "enrichments": {
+                "unique_vt_classifications": set(),
+                "unique_urlhaus_tags": set(),
+                "unique_countries": set(),
+                "unique_asns": set()
+            },
+            "alerts_summary": defaultdict(lambda: {"count": 0, "messages": []})
+        }
+
+        for hit in hits:
+            daily = cast(Dict[str, Any], hit['_source'])
+            for key in ['total', 'unique_ips', 'unique_usernames', 'unique_passwords']:
+                if key in daily.get('sessions', {}):
+                    monthly['sessions'][key] += daily['sessions'][key]
+            for key in ['total', 'unique']:
+                if key in daily.get('commands', {}):
+                    monthly['commands'][key] += daily['commands'][key]
+            for key in ['downloads_total', 'uploads_total', 'unique_hashes', 'recent_vt_submissions']:
+                if key in daily.get('files', {}):
+                    monthly['files'][key] += daily['files'][key]
+
+            for item in daily.get('files', {}).get('vt_classifications_top', []) or []:
+                if item.get('value'):
+                    monthly['enrichments']['unique_vt_classifications'].add(item['value'])
+            for item in daily.get('enrichments', {}).get('urlhaus_tags_top', []) or []:
+                if item.get('value'):
+                    monthly['enrichments']['unique_urlhaus_tags'].add(item['value'])
+            for item in daily.get('enrichments', {}).get('country_top', []) or []:
+                if item.get('value'):
+                    monthly['enrichments']['unique_countries'].add(item['value'])
+            for item in daily.get('enrichments', {}).get('asn_top', []) or []:
+                if item.get('value'):
+                    monthly['enrichments']['unique_asns'].add(item['value'])
+
+            for alert in daily.get('alerts', []) or []:
+                alert_type = alert.get('type', 'unknown')
+                monthly['alerts_summary'][alert_type]['count'] += 1
+                monthly['alerts_summary'][alert_type]['messages'].append({
+                    "date": daily.get('date_utc'),
+                    "message": alert.get('message'),
+                    "severity": alert.get('severity')
+                })
+
+        monthly['enrichments'] = {
+            'unique_vt_classifications': len(monthly['enrichments']['unique_vt_classifications']),
+            'unique_urlhaus_tags': len(monthly['enrichments']['unique_urlhaus_tags']),
+            'unique_countries': len(monthly['enrichments']['unique_countries']),
+            'unique_asns': len(monthly['enrichments']['unique_asns'])
+        }
+        monthly['sessions'] = dict(monthly['sessions'])
+        monthly['commands'] = dict(monthly['commands'])
+        monthly['files'] = dict(monthly['files'])
+        monthly['alerts_summary'] = dict(monthly['alerts_summary'])
+
+        if monthly['days_included'] > 0:
+            monthly['sessions']['daily_average'] = round(
+                monthly['sessions']['total'] / monthly['days_included'], 2
+            )
+            monthly['commands']['daily_average'] = round(
+                monthly['commands']['total'] / monthly['days_included'], 2
+            )
+            monthly['files']['daily_average_downloads'] = round(
+                monthly['files']['downloads_total'] / monthly['days_included'], 2
+            )
+
+        # Compare to previous month if available
+        prev_month = month - 1 if month > 1 else 12
+        prev_year = year if month > 1 else year - 1
+        prev_month_str = f"{prev_year:04d}-{prev_month:02d}"
+
+        prev_query = {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"term": {"year_month": prev_month_str}},
+                        {"term": {"report_type": "monthly"}},
+                        {"term": {"sensor": "aggregate"}}
+                    ]
+                }
+            },
+            "size": 1
+        }
+        prev_response = self.es.search(index="cowrie.reports.monthly-*", body=prev_query, ignore=[404])
+        prev_hits = prev_response.get('hits', {}).get('hits', [])
+        if prev_hits:
+            prev = cast(Dict[str, Any], prev_hits[0]['_source'])
+            def pct_change(curr, prev_val):
+                return round(((curr - prev_val) / prev_val * 100) if prev_val > 0 else 0, 2)
+            sessions_curr = monthly['sessions'].get('total', 0)
+            sessions_prev = prev.get('sessions', {}).get('total', 0)
+            uniq_curr = monthly['sessions'].get('unique_ips', 0)
+            uniq_prev = prev.get('sessions', {}).get('unique_ips', 0)
+            files_curr = monthly['files'].get('downloads_total', 0)
+            files_prev = prev.get('files', {}).get('downloads_total', 0)
+            monthly['trends'] = {
+                'sessions_change': pct_change(sessions_curr, sessions_prev),
+                'unique_ips_change': pct_change(uniq_curr, uniq_prev),
+                'files_change': pct_change(files_curr, files_prev)
+            }
+
+        return monthly
+    
+    def close(self):
+        """Close database connections."""
+        self.conn.close()
+        self.es.close()
+
+
+def main():
+    """Main entry point for the script."""
+    parser = argparse.ArgumentParser(description='Generate Elasticsearch reports from Cowrie data')
+    
+    # Database options
+    parser.add_argument('--db', default='../cowrieprocessor.sqlite',
+                        help='Path to SQLite database')
+    
+    # Elasticsearch options
+    parser.add_argument('--es-host', help='Elasticsearch host URL')
+    parser.add_argument('--es-username', help='Elasticsearch username')
+    parser.add_argument('--es-password', help='Elasticsearch password')
+    parser.add_argument('--es-api-key', help='Elasticsearch API key')
+    parser.add_argument('--es-cloud-id', help='Elastic Cloud ID')
+    parser.add_argument('--no-ssl-verify', action='store_true',
+                        help='Disable SSL certificate verification')
+    
+    # Report options
+    parser.add_argument('--sensor', help='Sensor name (default: hostname)')
+    parser.add_argument('--top-n', type=int, default=10,
+                        help='Number of top items to include (default: 10)')
+    parser.add_argument('--vt-recent-days', type=int, default=5,
+                        help='Days to consider VT submission recent (default: 5)')
+    
+    # Commands
+    subparsers = parser.add_subparsers(dest='command', help='Command to run')
+    
+    # Daily report command
+    daily_parser = subparsers.add_parser('daily', help='Generate daily report')
+    daily_parser.add_argument('--date', default=datetime.utcnow().strftime('%Y-%m-%d'),
+                              help='Date to process (YYYY-MM-DD)')
+    daily_parser.add_argument('--all-sensors', action='store_true',
+                              help='Generate reports for all sensors')
+    
+    # Backfill command
+    backfill_parser = subparsers.add_parser('backfill', help='Backfill reports for date range')
+    backfill_parser.add_argument('--start', required=True,
+                                  help='Start date (YYYY-MM-DD)')
+    backfill_parser.add_argument('--end', required=True,
+                                  help='End date (YYYY-MM-DD)')
+    backfill_parser.add_argument('--sensors', nargs='*',
+                                  help='Specific sensors to process')
+    
+    # Weekly rollup command
+    weekly_parser = subparsers.add_parser('weekly', help='Generate weekly rollup')
+    weekly_parser.add_argument('--week', 
+                                default=datetime.utcnow().strftime('%Y-W%U'),
+                                help='Week to process (YYYY-Www)')
+    
+    # Monthly rollup command
+    monthly_parser = subparsers.add_parser('monthly', help='Generate monthly rollup')
+    monthly_parser.add_argument('--month', 
+                                default=datetime.utcnow().strftime('%Y-%m'),
+                                help='Month to process (YYYY-MM)')
+    
+    args = parser.parse_args()
+    
+    # Get ES credentials from environment if not provided
+    es_host = args.es_host or os.getenv('ES_HOST')
+    es_username = args.es_username or os.getenv('ES_USERNAME')
+    es_password = args.es_password or os.getenv('ES_PASSWORD')
+    es_api_key = args.es_api_key or os.getenv('ES_API_KEY')
+    es_cloud_id = args.es_cloud_id or os.getenv('ES_CLOUD_ID')
+    # SSL verify from env (ES_VERIFY_SSL=false to disable)
+    env_verify = os.getenv('ES_VERIFY_SSL')
+    verify_ssl = True
+    if args.no_ssl_verify:
+        verify_ssl = False
+    elif env_verify is not None and env_verify.lower() in ('false', '0', 'no'):
+        verify_ssl = False
+    
+    if not (es_host or es_cloud_id):
+        logger.error("Either ES_HOST or ES_CLOUD_ID must be provided")
+        sys.exit(1)
+        
+    # Create reporter
+    reporter = CowrieReporter(
+        db_path=args.db,
+        es_host=es_host,
+        es_username=es_username,
+        es_password=es_password,
+        es_api_key=es_api_key,
+        es_cloud_id=es_cloud_id,
+        es_verify_ssl=verify_ssl,
+        sensor_name=args.sensor,
+        top_n=args.top_n,
+        vt_recent_days=args.vt_recent_days
+    )
+    
+    try:
+        if args.command == 'daily':
+            if args.all_sensors:
+                # Get all sensors from database
+                cur = reporter.conn.cursor()
+                cur.execute("SELECT DISTINCT hostname FROM sessions WHERE hostname IS NOT NULL")
+                sensors = [row['hostname'] for row in cur.fetchall()]
+                cur.close()
+                
+                # Generate reports for each sensor plus aggregate
+                for s in sensors:
+                    report = reporter.generate_daily_report(args.date, s)
+                    reporter.index_report(report)
+                # Aggregate
+                report = reporter.generate_daily_report(args.date, None)
+                reporter.index_report(report)
+            else:
+                # Single sensor or aggregate
+                report = reporter.generate_daily_report(args.date, args.sensor)
+                reporter.index_report(report)
+                print(json.dumps(report, indent=2))
+                
+        elif args.command == 'backfill':
+            reporter.backfill_daily(args.start, args.end, args.sensors)
+            
+        elif args.command == 'weekly':
+            report = reporter.generate_weekly_rollup(args.week)
+            if report:
+                reporter.index_report(report, "cowrie.reports.weekly-write")
+                print(json.dumps(report, indent=2))
+            else:
+                logger.error("Failed to generate weekly rollup")
+        elif args.command == 'monthly':
+            report = reporter.generate_monthly_rollup(args.month)
+            if report:
+                reporter.index_report(report, "cowrie.reports.monthly-write")
+                print(json.dumps(report, indent=2))
+            else:
+                logger.error("Failed to generate monthly rollup")
+                
+        else:
+            parser.print_help()
+            
+    finally:
+        reporter.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrate_sensors.py
+++ b/orchestrate_sensors.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Orchestrate running process_cowrie.py for multiple sensors from a TOML config.
+
+This runs sensors sequentially, passing per-sensor log paths and credentials,
+and writes to a shared central SQLite database with sensor tagging.
+"""
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import tomli as tomllib
+
+
+def load_config(path: Path) -> dict:
+    """Load TOML configuration from the given path."""
+    with open(path, 'rb') as f:
+        return tomllib.load(f)
+
+
+def build_cmd(processor: Path, db: str, sensor_cfg: dict, overrides: dict) -> list:
+    """Build a process_cowrie.py command for a sensor configuration."""
+    cmd = [sys.executable, str(processor)]
+
+    # Required basics
+    cmd += ["--sensor", sensor_cfg["name"]]
+    cmd += ["--logpath", sensor_cfg["logpath"]]
+    cmd += ["--db", db]
+
+    # Summarize days: override > sensor > global default 1
+    summarizedays = overrides.get("summarizedays") or sensor_cfg.get("summarizedays") or 1
+    cmd += ["--summarizedays", str(summarizedays)]
+
+    # Optional keys if present
+    for k in ["vtapi", "urlhausapi", "spurapi", "email", "dbxapi", "dbxkey", "dbxsecret", "dbxrefreshtoken"]:
+        if sensor_cfg.get(k):
+            cmd += [f"--{k}", str(sensor_cfg[k])]
+
+    return cmd
+
+
+def run_with_retries(cmd: list, max_retries: int = 2, base_sleep: float = 5.0) -> int:
+    """Run a command with retry and linear backoff."""
+    attempt = 0
+    while True:
+        attempt += 1
+        print(f"[orchestrate] Running: {' '.join(cmd)} (attempt {attempt})")
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode == 0:
+                if result.stdout:
+                    print(result.stdout)
+                if result.stderr:
+                    print(result.stderr, file=sys.stderr)
+                return 0
+            else:
+                print(result.stdout)
+                print(result.stderr, file=sys.stderr)
+        except Exception as e:  # pragma: no cover
+            print(f"[orchestrate] Exception: {e}", file=sys.stderr)
+
+        if attempt > max_retries:
+            print(f"[orchestrate] Failed after {max_retries} retries", file=sys.stderr)
+            return 1
+        sleep_for = base_sleep * attempt
+        print(f"[orchestrate] Retry in {sleep_for:.1f}s...")
+        time.sleep(sleep_for)
+
+
+def main():
+    """CLI entrypoint for orchestrating sensors from TOML config."""
+    ap = argparse.ArgumentParser(description="Run Cowrie processors for multiple sensors via TOML")
+    ap.add_argument("--config", default="sensors.toml", help="Path to TOML configuration")
+    ap.add_argument("--only", nargs="*", help="Subset of sensor names to run")
+    ap.add_argument("--processor", default="process_cowrie.py", help="Path to process_cowrie.py")
+    ap.add_argument("--db", help="Override central DB path")
+    ap.add_argument("--summarizedays", type=int, help="Override summarizedays for all sensors")
+    ap.add_argument("--max-retries", type=int, default=2, help="Max retries per sensor (default: 2)")
+    ap.add_argument("--pause-seconds", type=float, default=10.0, help="Pause between sensors (default: 10s)")
+    args = ap.parse_args()
+
+    cfg = load_config(Path(args.config))
+    global_cfg = cfg.get("global", {})
+    sensors = cfg.get("sensor", [])
+    if not sensors:
+        print("[orchestrate] No sensors defined in config", file=sys.stderr)
+        sys.exit(1)
+
+    # Determine DB
+    db = args.db or global_cfg.get("db") or "../cowrieprocessor.sqlite"
+    processor = Path(args.processor)
+
+    # Filter sensors if requested
+    if args.only:
+        names = set(args.only)
+        sensors = [s for s in sensors if s.get("name") in names]
+
+    failures = 0
+    for i, sensor_cfg in enumerate(sensors):
+        if not sensor_cfg.get("name") or not sensor_cfg.get("logpath"):
+            print(f"[orchestrate] Skipping incomplete sensor entry: {sensor_cfg}")
+            continue
+        cmd = build_cmd(processor, db, sensor_cfg, {"summarizedays": args.summarizedays})
+        rc = run_with_retries(cmd, max_retries=args.max_retries)
+        if rc != 0:
+            failures += 1
+        if i < len(sensors) - 1:
+            time.sleep(args.pause_seconds)
+
+    if failures:
+        print(f"[orchestrate] Completed with {failures} failures", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("[orchestrate] All sensors completed successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/quick_guide.md
+++ b/quick_guide.md
@@ -1,0 +1,259 @@
+# Cowrie Elasticsearch Reporting - Quick Implementation Guide
+
+## Setup Steps
+
+### 1. Install Dependencies
+```bash
+pip install elasticsearch>=8.0.0
+```
+
+### 2. Copy Files
+- Save `es_reports.py` to your dshield directory
+- Save index templates under `scripts/` (daily/weekly/monthly JSON files)
+
+### 3. Create Index Templates & ILM Policies (no delete)
+```bash
+# ILM: Daily hot 7d -> cold (no delete)
+curl -X PUT "localhost:9200/_ilm/policy/cowrie.reports.daily" -H "Content-Type: application/json" \
+  -d '{"policy":{"phases":{"hot":{"min_age":"0ms","actions":{"set_priority":{"priority":100}}},"cold":{"min_age":"7d","actions":{"set_priority":{"priority":0}}}}}}'
+
+# ILM: Weekly hot 30d -> cold (no delete)
+curl -X PUT "localhost:9200/_ilm/policy/cowrie.reports.weekly" -H "Content-Type: application/json" \
+  -d '{"policy":{"phases":{"hot":{"min_age":"0ms","actions":{"set_priority":{"priority":100}}},"cold":{"min_age":"30d","actions":{"set_priority":{"priority":0}}}}}}'
+
+# ILM: Monthly hot 90d -> cold (no delete)
+curl -X PUT "localhost:9200/_ilm/policy/cowrie.reports.monthly" -H "Content-Type: application/json" \
+  -d '{"policy":{"phases":{"hot":{"min_age":"0ms","actions":{"set_priority":{"priority":100}}},"cold":{"min_age":"90d","actions":{"set_priority":{"priority":0}}}}}}'
+
+# Index templates per type
+curl -X PUT "localhost:9200/_index_template/cowrie.reports.daily" -H "Content-Type: application/json" \
+  -d @scripts/cowrie.reports.daily-index.json
+curl -X PUT "localhost:9200/_index_template/cowrie.reports.weekly" -H "Content-Type: application/json" \
+  -d @scripts/cowrie.reports.weekly-index.json
+curl -X PUT "localhost:9200/_index_template/cowrie.reports.monthly" -H "Content-Type: application/json" \
+  -d @scripts/cowrie.reports.monthly-index.json
+```
+
+### 4. Set Environment Variables
+```bash
+export ES_HOST=localhost:9200
+export ES_USERNAME=elastic
+export ES_PASSWORD=your_password
+```
+
+### 5. Test Report Generation
+```bash
+# Test today's report
+python3 es_reports.py daily --all-sensors
+
+# Backfill last week
+python3 es_reports.py backfill --start 2024-12-14 --end 2024-12-20
+```
+
+### 6. Schedule with Cron
+```bash
+crontab -e
+# Add:
+30 4 * * * cd /home/cowrie/dshield && python3 es_reports.py daily --all-sensors
+0 5 * * 1 python3 es_reports.py weekly
+30 5 1 * * python3 es_reports.py monthly
+```
+
+## Key Features Implemented
+
+### Daily Reports (Per-sensor + Aggregate)
+- **Session Metrics**: Total, unique IPs, usernames, passwords, protocols
+- **Command Statistics**: Total, unique, top commands
+- **File Activity**: Downloads, uploads, VT classifications
+- **Enrichments**: URLhaus tags, ASN, country, SPUR data
+- **Abnormality Detection**: Uncommon command counts, recent VT submissions
+- **Alerts**: IP spikes, new VT classifications, high tunnel usage
+
+### Alert Thresholds
+- **IP Spike**: >50% increase from 7-day average
+- **New VT Classification**: Not seen in past 30 days
+- **High Tunnel Usage**: >30% of sessions
+
+### Multi-Sensor Support
+- Individual reports per sensor (honeypot1, honeypot2)
+- Aggregate report combining all sensors
+- Sensor name from hostname or override with `--sensor`
+
+### Data Structure
+```
+cowrie.reports.daily-*
+  └── sensor:date_utc (e.g., "honeypot1:2024-12-20")
+      ├── sessions (metrics)
+      ├── commands (statistics)
+      ├── files (activity)
+      ├── enrichments (3rd party data)
+      ├── abnormalities (detection flags)
+      └── alerts (threshold triggers)
+
+cowrie.reports.weekly-*
+  └── aggregate:YYYY-Www (e.g., "aggregate:2024-W51")
+      └── Aggregated daily metrics
+
+cowrie.reports.monthly-*
+  └── aggregate:YYYY-MM (e.g., "aggregate:2024-12")
+      ├── Aggregated daily metrics
+      └── trends (month-over-month changes)
+```
+
+## Usage Examples
+
+### Daily Operations
+```bash
+# Generate all reports for today
+python3 es_reports.py daily --all-sensors
+
+# Generate for specific date
+python3 es_reports.py daily --date 2024-12-19 --all-sensors
+
+# Single sensor only
+python3 es_reports.py daily --sensor honeypot1
+```
+
+### Backfilling
+```bash
+# Backfill date range
+python3 es_reports.py backfill --start 2024-11-01 --end 2024-11-30
+
+# Backfill specific sensors
+python3 es_reports.py backfill --start 2024-12-01 --end 2024-12-20 --sensors honeypot1 honeypot2
+```
+
+### Rollups
+```bash
+# Weekly rollup (current week)
+python3 es_reports.py weekly
+
+# Specific week
+python3 es_reports.py weekly --week 2024-W50
+
+# Monthly rollup
+python3 es_reports.py monthly --month 2024-11
+```
+
+## Kibana Queries
+
+### View Latest Daily Report
+```
+GET cowrie.reports.daily-*/_search
+{
+  "size": 1,
+  "sort": [{"date_utc": "desc"}],
+  "query": {"term": {"sensor": "aggregate"}}
+}
+```
+
+### Find High Severity Alerts
+```
+GET cowrie.reports.daily-*/_search
+{
+  "query": {
+    "nested": {
+      "path": "alerts",
+      "query": {"term": {"alerts.severity": "high"}}
+    }
+  }
+}
+```
+
+### Session Trend (Last 30 Days)
+```
+GET cowrie.reports.daily-*/_search
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"sensor": "aggregate"}},
+        {"range": {"date_utc": {"gte": "now-30d"}}}
+      ]
+    }
+  },
+  "aggs": {
+    "daily_sessions": {
+      "date_histogram": {
+        "field": "date_utc",
+        "calendar_interval": "day"
+      },
+      "aggs": {
+        "sessions": {"sum": {"field": "sessions.total"}}
+      }
+    }
+  }
+}
+```
+
+## Monitoring
+
+### Check Report Generation
+```bash
+# View last 5 reports
+curl -s "localhost:9200/cowrie.reports.daily-*/_search?size=5&sort=@timestamp:desc" | jq '.hits.hits[]._source | {date: .date_utc, sensor: .sensor, sessions: .sessions.total}'
+
+# Check for missing days
+python3 -c "
+from datetime import datetime, timedelta
+import requests
+for i in range(7):
+    date = (datetime.now() - timedelta(days=i)).strftime('%Y-%m-%d')
+    r = requests.get(f'http://localhost:9200/cowrie.reports.daily-*/_count?q=date_utc:{date}')
+    print(f'{date}: {r.json()[\"count\"]} reports')
+"
+```
+
+### View Alerts
+```bash
+# Today's alerts
+curl -s "localhost:9200/cowrie.reports.daily-*/_search?q=date_utc:$(date +%Y-%m-%d)" | \
+  jq '.hits.hits[]._source | select(.alerts | length > 0) | {sensor, alerts}'
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **No data in reports**
+   - Check SQLite has data: `sqlite3 cowrieprocessor.sqlite "SELECT COUNT(*) FROM sessions"`
+   - Verify date range has sessions
+
+2. **Connection errors**
+   - Test ES connection: `curl localhost:9200`
+   - Check credentials in environment
+
+3. **Missing enrichments**
+   - Enrichments show as null if not available
+   - Check if SPUR/URLhaus data exists in SQLite
+
+4. **Slow queries**
+   - Add index on timestamp: `CREATE INDEX idx_sessions_timestamp ON sessions(timestamp)`
+   - Limit date ranges for backfill
+
+### Debug Mode
+```bash
+# Enable debug logging
+python3 -c "import logging; logging.basicConfig(level=logging.DEBUG)" es_reports.py daily --date 2024-12-20
+```
+
+## Next Steps
+
+1. **Create Kibana Dashboard**
+   - Import visualizations for trends
+   - Set up alert watchers
+   
+2. **Tune Alert Thresholds**
+   - Adjust percentages based on your environment
+   - Add custom alerts for specific threats
+
+3. **Extend Metrics**
+   - Add GeoIP aggregations
+   - Include command sequence analysis
+   - Track persistence indicators
+
+4. **Integration**
+   - Forward high-severity alerts to SIEM
+   - Create Slack/email notifications
+   - Build executive reports from monthly rollups

--- a/refresh_cache_and_reports.py
+++ b/refresh_cache_and_reports.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Refresh indicator cache (VT/IP) and reindex recent ES reports.
+
+This script:
+ - Refreshes indicator_cache entries and seeds missing ones from the DB
+ - Respects TTLs for known vs. unknown VT hashes and IP lookups
+ - Applies request timeouts, retries with exponential backoff, and simple rate limits
+ - Re-generates recent daily/weekly/monthly reports within the configured hot windows
+
+Credentials for services are provided via CLI flags. Elasticsearch credentials are
+picked up by es_reports.py via environment variables or flags (not handled here).
+"""
+
+import argparse
+import json
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta
+
+import requests
+
+
+def parse_args():
+    """Parse CLI arguments for cache/report refresh."""
+    ap = argparse.ArgumentParser(description="Refresh indicator cache and recent ES reports")
+    ap.add_argument('--db', required=True, help='Path to central SQLite database')
+
+    # Services
+    ap.add_argument('--vtapi', help='VirusTotal API key')
+    ap.add_argument('--email', help='Email for DShield')
+    ap.add_argument('--urlhausapi', help='URLhaus API key')
+    ap.add_argument('--spurapi', help='SPUR.us API key')
+
+    # Request behavior
+    ap.add_argument('--api-timeout', type=int, default=15)
+    ap.add_argument('--api-retries', type=int, default=3)
+    ap.add_argument('--api-backoff', type=float, default=2.0)
+    ap.add_argument('--rate-vt', type=int, default=4)
+    ap.add_argument('--rate-dshield', type=int, default=30)
+    ap.add_argument('--rate-urlhaus', type=int, default=30)
+    ap.add_argument('--rate-spur', type=int, default=30)
+
+    # TTLs
+    ap.add_argument('--hash-ttl-days', type=int, default=30)
+    ap.add_argument('--hash-unknown-ttl-hours', type=int, default=12)
+    ap.add_argument('--ip-ttl-hours', type=int, default=12)
+
+    # What to refresh
+    ap.add_argument('--refresh-indicators', choices=['all', 'vt', 'ips', 'none'], default='all')
+    ap.add_argument('--refresh-reports', choices=['all', 'daily', 'weekly', 'monthly', 'none'], default='all')
+
+    # Hot windows (matches ILM)
+    ap.add_argument('--hot-daily-days', type=int, default=7)
+    ap.add_argument('--hot-weekly-days', type=int, default=30)
+    ap.add_argument('--hot-monthly-days', type=int, default=90)
+
+    return ap.parse_args()
+
+
+def setup_db(db_path: str) -> sqlite3.Connection:
+    """Open SQLite connection with busy timeout and Row factory."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute('PRAGMA busy_timeout=5000')
+    return conn
+
+
+def ensure_indicator_table(conn: sqlite3.Connection):
+    """Ensure indicator_cache table exists."""
+    conn.execute(
+        'CREATE TABLE IF NOT EXISTS indicator_cache('
+        ' service text, key text, last_fetched int, data text, PRIMARY KEY (service, key))'
+    )
+    conn.commit()
+
+
+class Refresher:
+    """Service refresher for indicator cache with rate limiting and retries."""
+    def __init__(self, args, conn: sqlite3.Connection):
+        """Initialize refresher with args and SQLite connection."""
+        self.args = args
+        self.conn = conn
+        self.vt = requests.Session()
+        self.dshield = requests.Session()
+        self.uh = requests.Session()
+        self.spur = requests.Session()
+        self.last_req = {'vt': 0.0, 'dshield': 0.0, 'urlhaus': 0.0, 'spur': 0.0}
+
+    def rate_limit(self, service: str):
+        """Enforce per-service requests-per-minute limits."""
+        now = time.time()
+        per_min = getattr(self.args, f'rate_{service}')
+        if per_min <= 0:
+            return
+        min_interval = 60.0 / float(per_min)
+        elapsed = now - self.last_req.get(service, 0.0)
+        if elapsed < min_interval:
+            time.sleep(min_interval - elapsed)
+        self.last_req[service] = time.time()
+
+    def cache_get(self, service: str, key: str):
+        """Get cache row (last_fetched, data) for service/key."""
+        cur = self.conn.cursor()
+        cur.execute('SELECT last_fetched, data FROM indicator_cache WHERE service=? AND key=?', (service, key))
+        return cur.fetchone()
+
+    def cache_upsert(self, service: str, key: str, data: str):
+        """Upsert cache row for service/key with data and current timestamp."""
+        cur = self.conn.cursor()
+        cur.execute(
+            'INSERT INTO indicator_cache(service, key, last_fetched, data) VALUES (?,?,?,?) '
+            'ON CONFLICT(service, key) DO UPDATE SET last_fetched=excluded.last_fetched, data=excluded.data',
+            (service, key, int(time.time()), data),
+        )
+        self.conn.commit()
+
+    def should_refresh_vt(self, key: str, row) -> bool:
+        """Decide if VT record should be refreshed based on TTL and unknown state."""
+        if not row:
+            return True
+        last, data = row
+        ttl = self.args.hash_ttl_days * 86400
+        try:
+            js = json.loads(data) if data else {}
+            is_unknown = (not isinstance(js, dict)) or ('data' not in js) or ('error' in js)
+            if is_unknown:
+                ttl = self.args.hash_unknown_ttl_hours * 3600
+        except Exception:
+            ttl = self.args.hash_unknown_ttl_hours * 3600
+        return (time.time() - last) >= ttl
+
+    def should_refresh_ip(self, row) -> bool:
+        """Decide if IP-based record should be refreshed based on TTL."""
+        if not row:
+            return True
+        last, _ = row
+        ttl = self.args.ip_ttl_hours * 3600
+        return (time.time() - last) >= ttl
+
+    def refresh_vt(self, hash_: str):
+        """Refresh VT cache entry for a file hash."""
+        if not self.args.vtapi:
+            return
+        url = f"https://www.virustotal.com/api/v3/files/{hash_}"
+        self.vt.headers.update({'X-Apikey': self.args.vtapi})
+        attempt = 0
+        while attempt < self.args.api_retries:
+            attempt += 1
+            try:
+                self.rate_limit('vt')
+                r = self.vt.get(url, timeout=self.args.api_timeout)
+                if r.status_code == 429:
+                    time.sleep(self.args.api_backoff * attempt)
+                    continue
+                if r.status_code == 404:
+                    self.cache_upsert('vt_file', hash_, json.dumps({"error": "not_found"}))
+                    return
+                r.raise_for_status()
+                self.cache_upsert('vt_file', hash_, r.text)
+                return
+            except Exception:
+                time.sleep(self.args.api_backoff * attempt)
+
+    def refresh_dshield(self, ip: str):
+        """Refresh DShield cache entry for an IP."""
+        if not self.args.email:
+            return
+        url = f"https://www.dshield.org/api/ip/{ip}?json"
+        attempt = 0
+        while attempt < self.args.api_retries:
+            attempt += 1
+            try:
+                self.rate_limit('dshield')
+                headers = {"User-Agent": f"DShield Research Query by {self.args.email}"}
+                r = self.dshield.get(url, headers=headers, timeout=self.args.api_timeout)
+                if r.status_code == 429:
+                    time.sleep(self.args.api_backoff * attempt)
+                    continue
+                r.raise_for_status()
+                self.cache_upsert('dshield_ip', ip, r.text)
+                return
+            except Exception:
+                time.sleep(self.args.api_backoff * attempt)
+
+    def refresh_urlhaus(self, host: str):
+        """Refresh URLhaus cache entry for a host/IP."""
+        if not self.args.urlhausapi:
+            return
+        url = "https://urlhaus-api.abuse.ch/v1/host/"
+        attempt = 0
+        while attempt < self.args.api_retries:
+            attempt += 1
+            try:
+                self.rate_limit('urlhaus')
+                r = self.uh.post(
+                    url,
+                    headers={'Auth-Key': self.args.urlhausapi},
+                    data={'host': host},
+                    timeout=self.args.api_timeout,
+                )
+                if r.status_code == 429:
+                    time.sleep(self.args.api_backoff * attempt)
+                    continue
+                r.raise_for_status()
+                self.cache_upsert('urlhaus_ip', host, r.text)
+                return
+            except Exception:
+                time.sleep(self.args.api_backoff * attempt)
+
+    def refresh_spur(self, ip: str):
+        """Refresh SPUR cache entry for an IP."""
+        if not self.args.spurapi:
+            return
+        url = f"https://api.spur.us/v2/context/{ip}"
+        self.spur.headers.update({'Token': self.args.spurapi})
+        attempt = 0
+        while attempt < self.args.api_retries:
+            attempt += 1
+            try:
+                self.rate_limit('spur')
+                r = self.spur.get(url, timeout=self.args.api_timeout)
+                if r.status_code == 429:
+                    time.sleep(self.args.api_backoff * attempt)
+                    continue
+                r.raise_for_status()
+                self.cache_upsert('spur_ip', ip, r.text)
+                return
+            except Exception:
+                time.sleep(self.args.api_backoff * attempt)
+
+    def seed_missing(self):
+        """Seed cache with DB-observed hashes and IPs missing from cache."""
+        # Seed missing VT hashes from files table
+        cur = self.conn.cursor()
+        cur.execute('''SELECT DISTINCT hash FROM files WHERE hash IS NOT NULL AND hash != '' ''')
+        hashes = [row['hash'] for row in cur.fetchall()]
+        for h in hashes:
+            if not self.cache_get('vt_file', h):
+                self.refresh_vt(h)
+
+        # Seed IPs from sessions/files
+        cur.execute(
+            "SELECT DISTINCT source_ip as ip FROM sessions "
+            "WHERE source_ip IS NOT NULL AND source_ip != ''"
+        )
+        ips = {row['ip'] for row in cur.fetchall()}
+        cur.execute(
+            "SELECT DISTINCT src_ip as ip FROM files "
+            "WHERE src_ip IS NOT NULL AND src_ip != ''"
+        )
+        ips |= {row['ip'] for row in cur.fetchall()}
+        for ip in ips:
+            if not self.cache_get('dshield_ip', ip):
+                self.refresh_dshield(ip)
+            if not self.cache_get('urlhaus_ip', ip):
+                self.refresh_urlhaus(ip)
+            if not self.cache_get('spur_ip', ip):
+                self.refresh_spur(ip)
+
+    def refresh_stale(self):
+        """Refresh any cache entries that are stale by TTL."""
+        # VT
+        if self.args.refresh_indicators in ('all', 'vt'):
+            cur = self.conn.cursor()
+            cur.execute("SELECT key, last_fetched, data FROM indicator_cache WHERE service='vt_file'")
+            for row in cur.fetchall():
+                key = row['key']
+                if self.should_refresh_vt(key, (row['last_fetched'], row['data'])):
+                    self.refresh_vt(key)
+
+        # IPs
+        if self.args.refresh_indicators in ('all', 'ips'):
+            for svc in ('dshield_ip', 'urlhaus_ip', 'spur_ip'):
+                cur = self.conn.cursor()
+                cur.execute("SELECT key, last_fetched FROM indicator_cache WHERE service=?", (svc,))
+                for row in cur.fetchall():
+                    key = row['key']
+                    stale = self.should_refresh_ip((row['last_fetched'], None))
+                    if not stale:
+                        continue
+                    if svc == 'dshield_ip':
+                        self.refresh_dshield(key)
+                    elif svc == 'urlhaus_ip':
+                        self.refresh_urlhaus(key)
+                    elif svc == 'spur_ip':
+                        self.refresh_spur(key)
+
+
+def refresh_reports(db_path: str, args):
+    """Rebuild recent daily/weekly/monthly reports within hot windows."""
+    # Daily for last N days
+    if args.refresh_reports in ('all', 'daily'):
+        for i in range(args.hot_daily_days):
+            date_str = (datetime.utcnow() - timedelta(days=i)).strftime('%Y-%m-%d')
+            subprocess.run([
+                sys.executable, 'es_reports.py', 'daily', '--all-sensors',
+                '--date', date_str, '--db', db_path,
+            ])
+
+    # Weekly covering last hot_weekly_days
+    if args.refresh_reports in ('all', 'weekly'):
+        start = datetime.utcnow() - timedelta(days=args.hot_weekly_days - 1)
+        end = datetime.utcnow()
+        curr = start
+        seen = set()
+        while curr <= end:
+            iso_year, iso_week, _ = curr.isocalendar()
+            key = f"{iso_year}-W{iso_week:02d}"
+            if key not in seen:
+                subprocess.run([sys.executable, 'es_reports.py', 'weekly', '--week', key, '--db', db_path])
+                seen.add(key)
+            curr += timedelta(days=1)
+
+    # Monthly covering last hot_monthly_days
+    if args.refresh_reports in ('all', 'monthly'):
+        start = datetime.utcnow() - timedelta(days=args.hot_monthly_days - 1)
+        months = set()
+        for i in range(args.hot_monthly_days):
+            d = datetime.utcnow() - timedelta(days=i)
+            months.add(d.strftime('%Y-%m'))
+        for ym in sorted(months):
+            subprocess.run([sys.executable, 'es_reports.py', 'monthly', '--month', ym, '--db', db_path])
+
+
+def main():
+    """Module entrypoint."""
+    args = parse_args()
+    conn = setup_db(args.db)
+    ensure_indicator_table(conn)
+
+    refresher = Refresher(args, conn)
+
+    if args.refresh_indicators != 'none':
+        refresher.seed_missing()
+        refresher.refresh_stale()
+
+    if args.refresh_reports != 'none':
+        refresh_reports(args.db, args)
+
+    print("Refresh complete")
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ dropbox>=11.36.2
 ipaddress>=1.0.23
 pathlib>=1.0.1
 python-dateutil>=2.8.2 
+elasticsearch>=8.0.0,<9.0.0
+tomli>=2.0.1

--- a/scripts/cowrie.reports.daily-index.json
+++ b/scripts/cowrie.reports.daily-index.json
@@ -1,0 +1,121 @@
+{
+  "index_patterns": ["cowrie.reports.daily-*"]
+,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index": {
+        "lifecycle": {
+          "name": "cowrie.reports.daily",
+          "rollover_alias": "cowrie.reports.daily-write"
+        },
+        "refresh_interval": "30s"
+      }
+    },
+    "mappings": {
+      "numeric_detection": true,
+      "_meta": {
+        "beat": "cowrie.reports"
+      },
+      "dynamic_templates": [
+        {
+          "strings_as_keyword": {
+            "match_mapping_type": "string",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {"type": "date"},
+        "date_utc": {"type": "date"},
+        "year_week": {"type": "keyword"},
+        "year_month": {"type": "keyword"},
+        "date_range": {
+          "properties": {"start": {"type": "date"}, "end": {"type": "date"}}
+        },
+        "sensor": {"type": "keyword"},
+        "generated_at": {"type": "date"},
+        "report_type": {"type": "keyword"},
+        "days_included": {"type": "integer"},
+        "sessions": {
+          "properties": {
+            "total": {"type": "long"},
+            "unique_ips": {"type": "long"},
+            "unique_usernames": {"type": "long"},
+            "unique_passwords": {"type": "long"},
+            "avg_commands": {"type": "float"},
+            "max_commands": {"type": "long"},
+            "min_commands": {"type": "long"},
+            "avg_duration": {"type": "float"},
+            "daily_average": {"type": "float"},
+            "protocols": {"type": "object"},
+            "top_usernames": {"type": "nested", "properties": {"value": {"type": "keyword"}, "count": {"type": "long"}}},
+            "top_passwords": {"type": "nested", "properties": {"value": {"type": "keyword"}, "count": {"type": "long"}}},
+            "top_combinations": {"type": "nested", "properties": {"value": {"type": "keyword"}, "count": {"type": "long"}}}
+          }
+        },
+        "commands": {
+          "properties": {
+            "total": {"type": "long"},
+            "unique": {"type": "long"},
+            "daily_average": {"type": "float"},
+            "top_commands": {
+              "type": "nested",
+              "properties": {
+                "value": {"type": "keyword", "fields": {"text": {"type": "match_only_text"}}},
+                "count": {"type": "long"}
+              }
+            }
+          }
+        },
+        "files": {
+          "properties": {
+            "downloads_total": {"type": "long"},
+            "uploads_total": {"type": "long"},
+            "unique_hashes": {"type": "long"},
+            "unique_vt_classifications": {"type": "long"},
+            "recent_vt_submissions": {"type": "long"},
+            "vt_classifications_top": {"type": "nested", "properties": {"value": {"type": "keyword"}, "count": {"type": "long"}}},
+            "top_hashes": {"type": "nested", "properties": {"value": {"type": "keyword"}, "count": {"type": "long"}}}
+          }
+        },
+        "enrichments": {
+          "properties": {
+            "urlhaus_tags_top": {"type": "nested", "properties": {"value": {"type": "keyword"}, "count": {"type": "long"}}},
+            "asn_top": {"type": "nested", "properties": {"value": {"type": "keyword"}, "count": {"type": "long"}}},
+            "country_top": {"type": "nested", "properties": {"value": {"type": "keyword"}, "count": {"type": "long"}}},
+            "spur_infrastructure_top": {"type": "nested", "properties": {"value": {"type": "keyword"}, "count": {"type": "long"}}},
+            "spur_tunnels": {"properties": {"total": {"type": "long"}, "anonymous": {"type": "long"}}}
+          }
+        },
+        "abnormalities": {
+          "properties": {
+            "uncommon_command_sessions": {"type": "long"},
+            "recent_vt_submission_sessions": {"type": "long"}
+          }
+        },
+        "alerts": {
+          "type": "nested",
+          "properties": {
+            "type": {"type": "keyword"},
+            "severity": {"type": "keyword"},
+            "message": {"type": "text", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}},
+            "current": {"type": "float"},
+            "average": {"type": "float"},
+            "percentage": {"type": "float"},
+            "classifications": {"type": "keyword"}
+          }
+        },
+        "alerts_summary": {
+          "type": "nested",
+          "properties": {"type": {"type": "keyword"}, "severity": {"type": "keyword"}, "message": {"type": "text"}}
+        }
+      }
+    }
+  }
+}
+}

--- a/scripts/cowrie.reports.monthly-index.json
+++ b/scripts/cowrie.reports.monthly-index.json
@@ -1,0 +1,40 @@
+{
+  "index_patterns": ["cowrie.reports.monthly-*"]
+,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index": {
+        "lifecycle": {
+          "name": "cowrie.reports.monthly",
+          "rollover_alias": "cowrie.reports.monthly-write"
+        },
+        "refresh_interval": "30s"
+      }
+    },
+    "mappings": {
+      "numeric_detection": true,
+      "_meta": {"beat": "cowrie.reports"},
+      "dynamic_templates": [
+        {"strings_as_keyword": {"match_mapping_type": "string", "mapping": {"ignore_above": 1024, "type": "keyword"}}}
+      ],
+      "properties": {
+        "@timestamp": {"type": "date"},
+        "year_month": {"type": "keyword"},
+        "date_range": {"properties": {"start": {"type": "date"}, "end": {"type": "date"}}},
+        "sensor": {"type": "keyword"},
+        "report_type": {"type": "keyword"},
+        "generated_at": {"type": "date"},
+        "days_included": {"type": "integer"},
+        "sessions": {"properties": {"total": {"type": "long"}, "unique_ips": {"type": "long"}, "daily_average": {"type": "float"}}},
+        "commands": {"properties": {"total": {"type": "long"}, "daily_average": {"type": "float"}}},
+        "files": {"properties": {"downloads_total": {"type": "long"}, "uploads_total": {"type": "long"}, "daily_average_downloads": {"type": "float"}}},
+        "enrichments": {"properties": {"unique_vt_classifications": {"type": "integer"}, "unique_urlhaus_tags": {"type": "integer"}, "unique_countries": {"type": "integer"}, "unique_asns": {"type": "integer"}}},
+        "alerts_summary": {"type": "object"},
+        "trends": {"properties": {"sessions_change": {"type": "float"}, "unique_ips_change": {"type": "float"}, "files_change": {"type": "float"}}}
+      }
+    }
+  }
+}
+

--- a/scripts/cowrie.reports.weekly-index.json
+++ b/scripts/cowrie.reports.weekly-index.json
@@ -1,0 +1,40 @@
+{
+  "index_patterns": ["cowrie.reports.weekly-*"]
+,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index": {
+        "lifecycle": {
+          "name": "cowrie.reports.weekly",
+          "rollover_alias": "cowrie.reports.weekly-write"
+        },
+        "refresh_interval": "30s"
+      }
+    },
+    "mappings": {
+      "numeric_detection": true,
+      "_meta": {"beat": "cowrie.reports"},
+      "dynamic_templates": [
+        {"strings_as_keyword": {"match_mapping_type": "string", "mapping": {"ignore_above": 1024, "type": "keyword"}}}
+      ],
+      "properties": {
+        "@timestamp": {"type": "date"},
+        "date_utc": {"type": "date"},
+        "year_week": {"type": "keyword"},
+        "year_month": {"type": "keyword"},
+        "date_range": {"properties": {"start": {"type": "date"}, "end": {"type": "date"}}},
+        "sensor": {"type": "keyword"},
+        "generated_at": {"type": "date"},
+        "report_type": {"type": "keyword"},
+        "days_included": {"type": "integer"},
+        "sessions": {"properties": {"total": {"type": "long"}, "unique_ips": {"type": "long"}, "unique_usernames": {"type": "long"}, "unique_passwords": {"type": "long"}, "daily_average": {"type": "float"}}},
+        "commands": {"properties": {"total": {"type": "long"}, "unique": {"type": "long"}, "daily_average": {"type": "float"}}},
+        "files": {"properties": {"downloads_total": {"type": "long"}, "uploads_total": {"type": "long"}, "unique_hashes": {"type": "long"}}},
+        "alerts_summary": {"type": "nested", "properties": {"type": {"type": "keyword"}, "severity": {"type": "keyword"}, "message": {"type": "text"}}}
+      }
+    }
+  }
+}
+

--- a/sensors.example.toml
+++ b/sensors.example.toml
@@ -1,0 +1,17 @@
+[global]
+db = "/mnt/dshield/data/db/cowrieprocessor.sqlite"
+
+[[sensor]]
+name = "honeypot-a"
+logpath = "/mnt/dshield/a/NSM/cowrie"
+summarizedays = 1
+email = "you@example.com"
+# vtapi = "..."
+# urlhausapi = "..."
+# spurapi = "..."
+
+[[sensor]]
+name = "honeypot-b"
+logpath = "/mnt/dshield/b/NSM/cowrie"
+summarizedays = 1
+


### PR DESCRIPTION
 This PR introduces a complete Elasticsearch reporting pipeline and multi‑sensor centralization for Cowrie honeypot data, adds robust API handling and caching, and provides orchestration + refresh utilities. It standardizes Elasticsearch
  writes via ILM write aliases with no‑delete retention, and documents everything.

  Motivation

  - Aggregate analytics across sensors to detect common attackers and trends.
  - Persist reliable daily/weekly/monthly reports into dedicated Elasticsearch indices.
  - Avoid API rate/timeout issues by adding caching, TTLs, retries, and backoff.
  - Provide tools for orchestrating multi‑sensor processing and refreshing caches and recent reports.

  Highlights

  - Central SQLite DB with per‑sensor tagging (hostname column on sessions/commands/files).
  - New es_reports.py writer with:
      - Daily reports per sensor + aggregate.
      - Weekly and monthly rollups from daily docs.
      - ILM write alias indexing (*-write).
  - Resilient API calls (VT, DShield, URLhaus, SPUR):
      - Timeouts, retries with exponential backoff, per‑service rate limits.
      - TTL‑aware indicator_cache table to reduce API load.
      - “Unknown” VT hashes rechecked sooner.
  - Orchestration + Refresh:
      - orchestrate_sensors.py to run all sensors from a TOML config.
      - refresh_cache_and_reports.py to refresh the DB cache and reindex recent reports (within hot windows).
  - ILM “no delete” policies:
      - Daily: move to cold after 7 days (no delete).
      - Weekly: move to cold after 30 days (no delete).
      - Monthly: move to cold after 90 days (no delete).

  Key Changes

  - process_cowrie.py
      - New CLI flags: --sensor, --db, --api-timeout, --api-retries, --api-backoff, --hash-ttl-days, --hash-unknown-ttl-hours, --ip-ttl-hours, --rate-vt, --rate-dshield, --rate-urlhaus, --rate-spur.
      - Central DB: Adds hostname column to sessions/commands/files; all reads/writes scoped by hostname.
      - Concurrency: PRAGMA journal_mode=WAL, busy_timeout=5000.
      - Indicator cache table: indicator_cache(service, key, last_fetched, data).
      - Network resilience: timeouts + retries + backoff + per‑service rate limits; VT unknown (404) cached and rechecked in 12 hours; IP lookups cached for 12 hours; VT known hashes cached for 30 days.
  - es_reports.py
      - Write to ILM write aliases: cowrie.reports.daily-write, weekly-write, monthly-write.
      - Daily per‑sensor + aggregate; --all-sensors supported.
      - Weekly and monthly rollups derived from daily docs.
      - Honors ES_VERIFY_SSL=false (or --no-ssl-verify).
      - Sensor scoping across all SQL queries; type hints; Ruff + mypy cleanups.
  - New scripts
      - orchestrate_sensors.py (TOML-based multi‑sensor runner; sequential with retries/backoff).
      - sensors.example.toml (example config).
      - refresh_cache_and_reports.py (refreshes indicator_cache and reindexes daily/weekly/monthly within hot windows).
  - Elasticsearch index templates (per type)
      - scripts/cowrie.reports.daily-index.json
      - scripts/cowrie.reports.weekly-index.json
      - scripts/cowrie.reports.monthly-index.json
      - All point to write aliases; ILM policies defined as no‑delete, cold‑only.
  - Requirements
      - elasticsearch>=8,<9, tomli (for Python <3.11).
  - Documentation
      - README: multi‑sensor central DB usage; ILM no‑delete policies; report generation; orchestration; refresh; new CLI options.
      - deployment_configs.md and quick_guide.md updated with no‑delete ILM and per‑type templates.
      - CHANGELOG: comprehensive Unreleased entry for all changes.
  - Removed
      - Deprecated reports_index_template.json.
      - Outdated snippet monthly_rollup.py.

  Configuration

  - Processor (per sensor) now supports:
      - --sensor <name> to tag rows with the sensor identity.
      - --db <path> to write into the central SQLite database.
      - API controls: --api-timeout, --api-retries, --api-backoff, per‑service --rate-*.
      - Cache TTLs: --hash-ttl-days (default 30), --hash-unknown-ttl-hours (default 12), --ip-ttl-hours (default 12).
  - Elasticsearch environment:
      - ES_HOST or ES_CLOUD_ID
      - ES_USERNAME/ES_PASSWORD or ES_API_KEY
      - ES_VERIFY_SSL=false to disable SSL verify (or --no-ssl-verify)

  ILM Setup

  - Create ILM policies (no delete):
      - Daily: hot 0ms -> cold after 7d
      - Weekly: hot 0ms -> cold after 30d
      - Monthly: hot 0ms -> cold after 90d
  - Install index templates:
      - _index_template/cowrie.reports.daily -> scripts/cowrie.reports.daily-index.json
      - _index_template/cowrie.reports.weekly -> scripts/cowrie.reports.weekly-index.json
      - _index_template/cowrie.reports.monthly -> scripts/cowrie.reports.monthly-index.json
  - Bootstrap indices with write aliases:
      - PUT cowrie.reports.daily-000001 with alias cowrie.reports.daily-write
      - Same for weekly/monthly

  Usage Examples

  - Processor (per sensor to central DB):
      - python process_cowrie.py --sensor honeypot-a --logpath /path/a --db /mnt/dshield/data/db/cowrieprocessor.sqlite --summarizedays 1
  - Orchestrate all sensors:
      - python orchestrate_sensors.py --config sensors.toml --max-retries 3
  - Reports (from central DB):
      - Daily: python es_reports.py daily --all-sensors --db /mnt/dshield/data/db/cowrieprocessor.sqlite --date 2025-09-14
      - Backfill: python es_reports.py backfill --start 2025-09-01 --end 2025-09-14 --db /mnt/dshield/data/db/cowrieprocessor.sqlite
      - Weekly: python es_reports.py weekly --week 2025-W37 --db /mnt/dshield/data/db/cowrieprocessor.sqlite
      - Monthly: python es_reports.py monthly --month 2025-09 --db /mnt/dshield/data/db/cowrieprocessor.sqlite
  - Refresh cache and recent reports:
      - python refresh_cache_and_reports.py --db /mnt/dshield/data/db/cowrieprocessor.sqlite --vtapi $VT_API --email you@example.com --urlhausapi $URLHAUS_API --spurapi $SPUR_API

  Validation

  - Ruff: Long lines wrapped; docstrings added for public functions/classes.
  - mypy: Optional types added; signatures adjusted; annotated dicts and lists; removed unused ignores; casting for ES hits.
  - Runtime: Verified that reads/writes include hostname so sensors don’t collide; DB concurrency tuned (WAL + busy timeout).

  Backward Compatibility

  - Existing per‑sensor DBs still work for local runs.
  - Moving to central DB requires leveraging --db + --sensor. New columns are added conditionally on startup; no historical merge required (logs retained for rebuild).
  - Templates changed: old combined template removed in favor of per‑type templates; references updated in docs.

  Risks / Notes

  - SQLite with multiple writers is acceptable (WAL improves concurrency), but staggering sensor runs or using orchestrator is recommended.
  - VT, DShield, URLhaus, SPUR are rate‑limited via flags; adjust as needed for your quotas.
  - Make sure write aliases and ILM policies are created prior to indexing.

  Checklist

  - [x] Central DB + sensor tagging implemented
  - [x] Daily/weekly/monthly writers indexing to write aliases
  - [x] ILM policies and templates documented and included
  - [x] Orchestrator + TOML example
  - [x] Refresh tool for cache/reports
  - [x] Robust API handling (timeouts, backoff, rate limits)
  - [x] README, quick guide, deployment docs updated
  - [x] CHANGELOG updated
  - [x] Ruff and mypy alignment for modified/new code