### PR TITLE
Feat: Secrets handling for multiple platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Lint and Type Check
+
+on:
+  push:
+    branches: [ main, master, '**' ]
+  pull_request:
+    branches: [ main, master, '**' ]
+
+jobs:
+  lint-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff==0.12.11 mypy==1.14.1 types-requests==2.32.0.20240914
+
+      - name: Ruff (lint + import order)
+        run: |
+          ruff --version
+          ruff check .
+
+      - name: MyPy (type check)
+        run: |
+          mypy --version
+          mypy .
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - types-requests==2.32.0.20240914

--- a/cowrie_malware_enrichment.py
+++ b/cowrie_malware_enrichment.py
@@ -17,6 +17,8 @@ from functools import lru_cache
 
 import requests
 
+from secrets_resolver import is_reference, resolve_secret
+
 basic_with_time_format = '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
 logging_fhandler = logging.FileHandler("cowrie_malware_enrichment.log")
 logging_fhandler.setFormatter(logging.Formatter(basic_with_time_format))
@@ -27,28 +29,27 @@ logging.root.addHandler(logging_fhandler)
 logging.root.addHandler(stdout_handler)
 logging.root.setLevel(logging.DEBUG)
 
-parser = argparse.ArgumentParser(
-    description='DShield Honeypot Cowrie Data Identifiers'
-)
+parser = argparse.ArgumentParser(description='DShield Honeypot Cowrie Data Identifiers')
 parser.add_argument(
-    '--filepath', dest='filepath', type=str,
+    '--filepath',
+    dest='filepath',
+    type=str,
     help='Path of cowrie json log file',
     default='/srv/cowrie/var/log/cowrie/cowrie.json',
 )
 parser.add_argument(
-    '--directory', dest='directory', type=str,
-    help='Path of cowrie json log files', default=None,
+    '--directory',
+    dest='directory',
+    type=str,
+    help='Path of cowrie json log files',
+    default=None,
 )
+parser.add_argument('--vtapi', dest='vtapi', type=str, help='VirusTotal API key (required for VT data lookup)')
 parser.add_argument(
-    '--vtapi', dest='vtapi', type=str,
-    help='VirusTotal API key (required for VT data lookup)'
-)
-parser.add_argument(
-    '--timespan', dest='timespan', type=int,
-    help=(
-        'Number of seconds in the past to look for data '
-        '(60 would be any data logged in the last minute)'
-    ),
+    '--timespan',
+    dest='timespan',
+    type=int,
+    help=('Number of seconds in the past to look for data ' '(60 would be any data logged in the last minute)'),
     default=None,
 )
 args = parser.parse_args()
@@ -58,12 +59,18 @@ directory = args.directory
 if directory is not None:
     if directory.endswith("/"):
         directory = directory[:-1]
-vt_api = args.vtapi
+vt_api = args.vtapi or os.getenv('VT_API_KEY')
+try:
+    if is_reference(vt_api):
+        vt_api = resolve_secret(vt_api)
+except Exception:
+    pass
 timespan = args.timespan
 
 vt_session = requests.session()
 
-def find_cowrie_malware(filename, timespan = None):
+
+def find_cowrie_malware(filename, timespan=None):
     """Find file transfer events in a Cowrie log and enrich via VT.
 
     Args:
@@ -85,26 +92,19 @@ def find_cowrie_malware(filename, timespan = None):
     with open(filename, "r") as file:
         for each_line in file:
             json_data = json.loads(each_line)
-            cowrie_data.append (json_data)
+            cowrie_data.append(json_data)
 
     for each_log in cowrie_data:
-        if (
-            each_log["eventid"] == "cowrie.session.file_download"
-            or each_log["eventid"] == "cowrie.session.file_upload"
-        ):
-            timestamp = datetime.datetime.strptime(
-                each_log['timestamp'], "%Y-%m-%dT%H:%M:%S.%fZ"
-            )
-            if (
-                timespan is None
-                or timespan > (datetime.datetime.now() - timestamp).total_seconds()
-            ):
+        if each_log["eventid"] == "cowrie.session.file_download" or each_log["eventid"] == "cowrie.session.file_upload":
+            timestamp = datetime.datetime.strptime(each_log['timestamp'], "%Y-%m-%dT%H:%M:%S.%fZ")
+            if timespan is None or timespan > (datetime.datetime.now() - timestamp).total_seconds():
                 logging.debug(
                     f"{each_log['eventid']} found in session {each_log['session']} "
                     f"at {each_log['timestamp']}: hash {each_log['shasum']}"
                 )
                 if each_log['shasum'] not in existing_hashes_logged:
                     vt_lookup(vt_api, each_log['shasum'])
+
 
 def find_exising_logs(filename="vt_data"):
     """Return the set of hashes already present in a VT log file.
@@ -122,15 +122,11 @@ def find_exising_logs(filename="vt_data"):
                 try:
                     json_data = json.loads(each_line)
                     if "hash" in json_data:
-                        hashes.add(json_data["hash"])    
+                        hashes.add(json_data["hash"])
                 except Exception:
-                    logging.error(
-                        (
-                            "Issue reading json from %s. Maybe missing data: '%s'"
-                            % (filename, each_line)
-                        )
-                    )
+                    logging.error(("Issue reading json from %s. Maybe missing data: '%s'" % (filename, each_line)))
     return hashes
+
 
 @lru_cache
 def vt_lookup(vt_api, hash="a8460f446be540410004b1a8db4083773fa46f7fe76fa84219c93daa1669f8f2"):
@@ -170,15 +166,16 @@ def vt_lookup(vt_api, hash="a8460f446be540410004b1a8db4083773fa46f7fe76fa84219c9
                 if "meaningful_name" in json_response["data"]["attributes"]:
                     vt_data["filename"] = json_response["data"]["attributes"]["meaningful_name"]
                 if "popular_threat_classification" in json_response["data"]["attributes"]:
-                    vt_data["classification"] = json_response["data"]["attributes"][
-                        "popular_threat_classification"
-                    ]["suggested_threat_label"]
-        
+                    vt_data["classification"] = json_response["data"]["attributes"]["popular_threat_classification"][
+                        "suggested_threat_label"
+                    ]
+
         filehandle = open("vt_data", "a")
-        filehandle.write(json.dumps(vt_data) +"\n")
+        filehandle.write(json.dumps(vt_data) + "\n")
         filehandle.close()
 
-if directory is not None:         
+
+if directory is not None:
     for each_file in os.listdir(directory):
         if "cowrie.json" in each_file:
             find_cowrie_malware(f"{directory}/{each_file}", timespan)

--- a/es_reports.py
+++ b/es_reports.py
@@ -17,17 +17,16 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 from elasticsearch import Elasticsearch
 
+from secrets_resolver import is_reference, resolve_secret
+
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 
 class CowrieReporter:
     """Generate Elasticsearch reports from Cowrie SQLite data."""
-    
+
     def __init__(
         self,
         db_path: str = "../cowrieprocessor.sqlite",
@@ -40,10 +39,10 @@ class CowrieReporter:
         sensor_name: Optional[str] = None,
         top_n: int = 10,
         vt_recent_days: int = 5,
-        timezone_str: str = "UTC"
+        timezone_str: str = "UTC",
     ):
         """Initialize reporter with database and Elasticsearch connections.
-        
+
         Args:
             db_path: Path to SQLite database
             es_host: Elasticsearch host URL
@@ -62,7 +61,7 @@ class CowrieReporter:
         self.vt_recent_days = vt_recent_days
         self.timezone = timezone_str
         self.sensor_name = sensor_name or os.uname().nodename
-        
+
         # Connect to SQLite
         self.conn = sqlite3.connect(db_path)
         self.conn.row_factory = sqlite3.Row
@@ -70,7 +69,7 @@ class CowrieReporter:
             self.conn.execute('PRAGMA busy_timeout=5000')
         except Exception:
             pass
-        
+
         # Connect to Elasticsearch
         es_config: Dict[str, Any] = {}
         if es_cloud_id:
@@ -79,22 +78,22 @@ class CowrieReporter:
             es_config['hosts'] = [es_host]
         else:
             raise ValueError("Either es_host or es_cloud_id must be provided")
-            
+
         if es_api_key:
             es_config['api_key'] = es_api_key
         elif es_username and es_password:
             es_config['basic_auth'] = (es_username, es_password)
-        
+
         es_config['verify_certs'] = es_verify_ssl
-        
+
         self.es = Elasticsearch(**es_config)
-        
+
         # Verify connection
         if not self.es.ping():
             raise ConnectionError("Cannot connect to Elasticsearch")
-            
+
         logger.info("Connected to Elasticsearch and SQLite database")
-        
+
     def _get_top_n(self, items: List[Any], n: Optional[int] = None) -> List[Dict[str, Any]]:
         """Get top N items with counts from a list."""
         if not items:
@@ -102,33 +101,33 @@ class CowrieReporter:
         n = n or self.top_n
         counter = Counter(items)
         return [{"value": k, "count": v} for k, v in counter.most_common(n)]
-    
+
     def _get_date_range(self, date_utc: str) -> Tuple[int, int]:
         """Convert date string to epoch timestamps for day boundaries."""
         dt = datetime.strptime(date_utc, "%Y-%m-%d").replace(tzinfo=timezone.utc)
         start_epoch = int(dt.timestamp())
         end_epoch = int((dt + timedelta(days=1)).timestamp())
         return start_epoch, end_epoch
-    
+
     def generate_daily_report(self, date_utc: str, sensor: Optional[str] = None) -> Dict[str, Any]:
         """Generate daily report for a specific sensor or aggregate.
-        
+
         Args:
             date_utc: Date in YYYY-MM-DD format
             sensor: Specific sensor name, or None for aggregate
-            
+
         Returns:
             Report document ready for indexing
         """
         start_epoch, end_epoch = self._get_date_range(date_utc)
-        
+
         # Build sensor filter
         sensor_filter = ""
         params: List[Any] = [start_epoch, end_epoch]
         if sensor:
             sensor_filter = " AND hostname = ?"
             params.append(sensor)
-        
+
         # Initialize report structure
         report: Dict[str, Any] = {
             "@timestamp": datetime.utcnow().isoformat() + "Z",
@@ -141,12 +140,12 @@ class CowrieReporter:
             "files": {},
             "enrichments": {},
             "abnormalities": {},
-            "alerts": []
+            "alerts": [],
         }
-        
+
         # Query sessions
         cur = self.conn.cursor()
-        
+
         # Basic session metrics
         query = f"""
             SELECT 
@@ -161,10 +160,10 @@ class CowrieReporter:
             FROM sessions 
             WHERE timestamp >= ? AND timestamp < ?{sensor_filter}
         """
-        
+
         cur.execute(query, tuple(params))
         row = cur.fetchone()
-        
+
         report['sessions'] = {
             'total': row['total_sessions'] or 0,
             'unique_ips': row['unique_ips'] or 0,
@@ -173,9 +172,9 @@ class CowrieReporter:
             'avg_commands': round(row['avg_commands'] or 0, 2),
             'max_commands': row['max_commands'] or 0,
             'min_commands': row['min_commands'] or 0,
-            'avg_duration': round(row['avg_duration'] or 0, 2)
+            'avg_duration': round(row['avg_duration'] or 0, 2),
         }
-        
+
         # Protocol breakdown
         query = f"""
             SELECT protocol, COUNT(*) as count
@@ -189,7 +188,7 @@ class CowrieReporter:
             if row['protocol']:
                 protocols[row['protocol']] = row['count']
         report['sessions']['protocols'] = protocols
-        
+
         # Top usernames, passwords, and combinations
         query = f"""
             SELECT username, COUNT(*) as count
@@ -201,10 +200,9 @@ class CowrieReporter:
         """
         cur.execute(query, (*tuple(params), self.top_n))
         report['sessions']['top_usernames'] = [
-            {"value": row['username'], "count": row['count']} 
-            for row in cur.fetchall() if row['username']
+            {"value": row['username'], "count": row['count']} for row in cur.fetchall() if row['username']
         ]
-        
+
         query = f"""
             SELECT password, COUNT(*) as count
             FROM sessions
@@ -215,10 +213,9 @@ class CowrieReporter:
         """
         cur.execute(query, (*tuple(params), self.top_n))
         report['sessions']['top_passwords'] = [
-            {"value": row['password'], "count": row['count']}
-            for row in cur.fetchall() if row['password']
+            {"value": row['password'], "count": row['count']} for row in cur.fetchall() if row['password']
         ]
-        
+
         query = f"""
             SELECT username || ':' || password as combo, COUNT(*) as count
             FROM sessions
@@ -229,10 +226,9 @@ class CowrieReporter:
         """
         cur.execute(query, (*tuple(params), self.top_n))
         report['sessions']['top_combinations'] = [
-            {"value": row['combo'], "count": row['count']}
-            for row in cur.fetchall() if row['combo']
+            {"value": row['combo'], "count": row['count']} for row in cur.fetchall() if row['combo']
         ]
-        
+
         # Command statistics
         query = f"""
             SELECT 
@@ -244,12 +240,9 @@ class CowrieReporter:
         """
         cur.execute(query, tuple(params))
         row = cur.fetchone()
-        
-        report['commands'] = {
-            'total': row['total_commands'] or 0,
-            'unique': row['unique_commands'] or 0
-        }
-        
+
+        report['commands'] = {'total': row['total_commands'] or 0, 'unique': row['unique_commands'] or 0}
+
         # Top commands
         query = f"""
             SELECT command, COUNT(*) as count
@@ -262,10 +255,9 @@ class CowrieReporter:
         """
         cur.execute(query, (*tuple(params), self.top_n))
         report['commands']['top_commands'] = [
-            {"value": row['command'], "count": row['count']}
-            for row in cur.fetchall() if row['command']
+            {"value": row['command'], "count": row['count']} for row in cur.fetchall() if row['command']
         ]
-        
+
         # File activity
         query = f"""
             SELECT 
@@ -279,14 +271,14 @@ class CowrieReporter:
         """
         cur.execute(query, tuple(params))
         row = cur.fetchone()
-        
+
         report['files'] = {
             'downloads_total': row['downloads'] or 0,
             'uploads_total': row['uploads'] or 0,
             'unique_hashes': row['unique_hashes'] or 0,
-            'unique_vt_classifications': row['unique_vt_classifications'] or 0
+            'unique_vt_classifications': row['unique_vt_classifications'] or 0,
         }
-        
+
         # VT classifications breakdown
         query = f"""
             SELECT vt_threat_classification, COUNT(*) as count
@@ -301,9 +293,10 @@ class CowrieReporter:
         cur.execute(query, (*tuple(params), self.top_n))
         report['files']['vt_classifications_top'] = [
             {"value": row['vt_threat_classification'], "count": row['count']}
-            for row in cur.fetchall() if row['vt_threat_classification']
+            for row in cur.fetchall()
+            if row['vt_threat_classification']
         ]
-        
+
         # Recent VT submissions
         recent_cutoff = int((datetime.utcnow() - timedelta(days=self.vt_recent_days)).timestamp())
         query = """
@@ -316,7 +309,7 @@ class CowrieReporter:
         cur.execute(query, (*tuple(params), recent_cutoff))
         row = cur.fetchone()
         report['files']['recent_vt_submissions'] = row['recent_sessions'] or 0
-        
+
         # Top file hashes
         query = f"""
             SELECT hash, COUNT(*) as count
@@ -329,12 +322,11 @@ class CowrieReporter:
         """
         cur.execute(query, (*tuple(params), self.top_n))
         report['files']['top_hashes'] = [
-            {"value": row['hash'][:16] + "...", "count": row['count']}
-            for row in cur.fetchall() if row['hash']
+            {"value": row['hash'][:16] + "...", "count": row['count']} for row in cur.fetchall() if row['hash']
         ]
-        
+
         # Enrichment data (URLhaus, ASN, Country, SPUR)
-        
+
         # URLhaus tags
         query = f"""
             SELECT urlhaus_tag
@@ -348,7 +340,7 @@ class CowrieReporter:
             if row['urlhaus_tag']:
                 all_tags.extend([t.strip() for t in row['urlhaus_tag'].split(',')])
         report['enrichments']['urlhaus_tags_top'] = self._get_top_n(all_tags)
-        
+
         # Top ASNs
         query = f"""
             SELECT asname, COUNT(*) as count
@@ -361,10 +353,9 @@ class CowrieReporter:
         """
         cur.execute(query, (*tuple(params), self.top_n))
         report['enrichments']['asn_top'] = [
-            {"value": row['asname'], "count": row['count']}
-            for row in cur.fetchall() if row['asname']
+            {"value": row['asname'], "count": row['count']} for row in cur.fetchall() if row['asname']
         ]
-        
+
         # Top countries
         query = f"""
             SELECT ascountry, COUNT(*) as count
@@ -377,10 +368,9 @@ class CowrieReporter:
         """
         cur.execute(query, (*tuple(params), self.top_n))
         report['enrichments']['country_top'] = [
-            {"value": row['ascountry'], "count": row['count']}
-            for row in cur.fetchall() if row['ascountry']
+            {"value": row['ascountry'], "count": row['count']} for row in cur.fetchall() if row['ascountry']
         ]
-        
+
         # SPUR infrastructure types
         query = f"""
             SELECT spur_infrastructure, COUNT(*) as count
@@ -394,9 +384,10 @@ class CowrieReporter:
         cur.execute(query, (*tuple(params), self.top_n))
         report['enrichments']['spur_infrastructure_top'] = [
             {"value": row['spur_infrastructure'], "count": row['count']}
-            for row in cur.fetchall() if row['spur_infrastructure']
+            for row in cur.fetchall()
+            if row['spur_infrastructure']
         ]
-        
+
         # SPUR tunnel usage
         query = f"""
             SELECT 
@@ -409,11 +400,11 @@ class CowrieReporter:
         row = cur.fetchone()
         report['enrichments']['spur_tunnels'] = {
             'total': row['tunnel_sessions'] or 0,
-            'anonymous': row['anonymous_tunnels'] or 0
+            'anonymous': row['anonymous_tunnels'] or 0,
         }
-        
+
         # Abnormality detection (based on process_cowrie.py logic)
-        
+
         # Get command count distribution for anomaly detection
         query = f"""
             SELECT total_commands, COUNT(*) as session_count
@@ -424,13 +415,13 @@ class CowrieReporter:
         """
         cur.execute(query, tuple(params))
         command_distribution = list(cur.fetchall())
-        
+
         if command_distribution:
             # Find uncommon command counts (bottom 2/3 by frequency)
             sorted_counts = sorted(command_distribution, key=lambda x: x['session_count'])
-            threshold_idx = int(len(sorted_counts) * 2/3)
+            threshold_idx = int(len(sorted_counts) * 2 / 3)
             uncommon_counts = set(row['total_commands'] for row in sorted_counts[:threshold_idx])
-            
+
             # Count sessions with uncommon command counts
             query = f"""
                 SELECT COUNT(DISTINCT session) as count
@@ -446,13 +437,13 @@ class CowrieReporter:
                 report['abnormalities']['uncommon_command_sessions'] = 0
         else:
             report['abnormalities']['uncommon_command_sessions'] = 0
-            
+
         # Sessions with recent VT submissions
         report['abnormalities']['recent_vt_submission_sessions'] = report['files']['recent_vt_submissions']
-        
+
         # Alert generation
         alerts: List[Dict[str, Any]] = []
-        
+
         # Alert: Spike in unique IPs (>50% increase from 7-day average)
         week_ago = (datetime.strptime(date_utc, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
         query = f"""
@@ -467,23 +458,25 @@ class CowrieReporter:
         cur.execute(query, (week_start, start_epoch, *([sensor] if sensor else [])))
         row = cur.fetchone()
         avg_ips = row['avg_ips'] or 0
-        
+
         if avg_ips > 0 and report['sessions']['unique_ips'] > avg_ips * 1.5:
             pct_increase = int((report['sessions']['unique_ips'] / avg_ips - 1) * 100)
             msg = f"Unique IPs increased by {pct_increase}% from 7-day average"
-            alerts.append({
-                "type": "ip_spike",
-                "severity": "medium",
-                "message": msg,
-                "current": report['sessions']['unique_ips'],
-                "average": round(avg_ips, 2)
-            })
-        
+            alerts.append(
+                {
+                    "type": "ip_spike",
+                    "severity": "medium",
+                    "message": msg,
+                    "current": report['sessions']['unique_ips'],
+                    "average": round(avg_ips, 2),
+                }
+            )
+
         # Alert: New VT classification not seen in past 30 days
         if report['files']['vt_classifications_top']:
             month_ago = (datetime.strptime(date_utc, "%Y-%m-%d") - timedelta(days=30)).strftime("%Y-%m-%d")
             month_start, _ = self._get_date_range(month_ago)
-            
+
             query = f"""
                 SELECT DISTINCT vt_threat_classification
                 FROM files f
@@ -491,66 +484,66 @@ class CowrieReporter:
                 WHERE s.timestamp >= ? AND s.timestamp < ?{(' AND s.hostname = ?' if sensor else '')}
                 AND vt_threat_classification IS NOT NULL
             """
-            cur.execute(query, (month_start, start_epoch, *( [sensor] if sensor else [])))
+            cur.execute(query, (month_start, start_epoch, *([sensor] if sensor else [])))
             past_classifications = set(row['vt_threat_classification'] for row in cur.fetchall())
-            
+
             cur.execute(query, tuple(params))
             today_classifications = set(row['vt_threat_classification'] for row in cur.fetchall())
-            
+
             new_classifications = today_classifications - past_classifications
             if new_classifications:
-                alerts.append({
-                    "type": "new_vt_classification",
-                    "severity": "high",
-                    "message": f"New VT classifications detected: {', '.join(new_classifications)}",
-                    "classifications": list(new_classifications)
-                })
-        
+                alerts.append(
+                    {
+                        "type": "new_vt_classification",
+                        "severity": "high",
+                        "message": f"New VT classifications detected: {', '.join(new_classifications)}",
+                        "classifications": list(new_classifications),
+                    }
+                )
+
         # Alert: High percentage of tunneled traffic
         if report['sessions']['total'] > 0:
             tunnel_pct = (report['enrichments']['spur_tunnels']['total'] / report['sessions']['total']) * 100
             if tunnel_pct > 30:  # More than 30% tunneled
-                alerts.append({
-                    "type": "high_tunnel_usage",
-                    "severity": "medium",
-                    "message": f"{tunnel_pct:.1f}% of sessions using tunnels/proxies",
-                    "percentage": round(tunnel_pct, 2)
-                })
-        
+                alerts.append(
+                    {
+                        "type": "high_tunnel_usage",
+                        "severity": "medium",
+                        "message": f"{tunnel_pct:.1f}% of sessions using tunnels/proxies",
+                        "percentage": round(tunnel_pct, 2),
+                    }
+                )
+
         report['alerts'] = alerts
-        
+
         cur.close()
         return report
-    
+
     def index_report(self, report: Dict[str, Any], index_pattern: str = "cowrie.reports.daily-write") -> bool:
         """Index a report document to Elasticsearch.
-        
+
         Args:
             report: Report document
             index_pattern: Index pattern to use
-            
+
         Returns:
             Success status
         """
         # Always write to the ILM write alias. If a base name was provided, append -write.
         index_alias = index_pattern if index_pattern.endswith('-write') else f"{index_pattern}-write"
         doc_id = f"{report['sensor']}:{report['date_utc']}"
-        
+
         try:
-            self.es.index(
-                index=index_alias,
-                id=doc_id,
-                document=report
-            )
+            self.es.index(index=index_alias, id=doc_id, document=report)
             logger.info(f"Indexed report {doc_id} to {index_alias}")
             return True
         except Exception as e:
             logger.error(f"Failed to index report {doc_id}: {e}")
             return False
-    
+
     def backfill_daily(self, start_date: str, end_date: str, sensors: Optional[List[str]] = None) -> None:
         """Backfill daily reports for a date range.
-        
+
         Args:
             start_date: Start date (YYYY-MM-DD)
             end_date: End date (YYYY-MM-DD), inclusive
@@ -562,21 +555,21 @@ class CowrieReporter:
             cur.execute("SELECT DISTINCT hostname FROM sessions WHERE hostname IS NOT NULL")
             sensors = [row['hostname'] for row in cur.fetchall()]
             cur.close()
-            
+
         # Always include aggregate
         sensors_to_process: List[Optional[str]] = [*sensors, None]
-        
+
         # Iterate through dates
         current = datetime.strptime(start_date, "%Y-%m-%d")
         end = datetime.strptime(end_date, "%Y-%m-%d")
-        
+
         total_reports = 0
         failed_reports = 0
-        
+
         while current <= end:
             date_str = current.strftime("%Y-%m-%d")
             logger.info(f"Processing {date_str}")
-            
+
             for sensor in sensors_to_process:
                 sensor_name = sensor or "aggregate"
                 try:
@@ -588,17 +581,17 @@ class CowrieReporter:
                 except Exception as e:
                     logger.error(f"Failed to generate report for {sensor_name} on {date_str}: {e}")
                     failed_reports += 1
-                    
+
             current += timedelta(days=1)
-            
+
         logger.info(f"Backfill complete: {total_reports} indexed, {failed_reports} failed")
-    
+
     def generate_weekly_rollup(self, year_week: str) -> Optional[Dict[str, Any]]:
         """Generate weekly rollup from daily reports.
-        
+
         Args:
             year_week: Year and week in YYYY-Www format
-            
+
         Returns:
             Weekly rollup document
         """
@@ -606,46 +599,44 @@ class CowrieReporter:
         year_s, week_s = year_week.split('-W')
         year_i = int(year_s)
         week_i = int(week_s)
-        
+
         # Calculate date range for the week
         jan1 = datetime(year_i, 1, 1)
         week_start = jan1 + timedelta(days=(week_i - 1) * 7 - jan1.weekday())
         week_end = week_start + timedelta(days=6)
-        
+
         # Query daily reports from Elasticsearch
         query = {
             "query": {
                 "bool": {
                     "filter": [
-                        {"range": {"date_utc": {
-                            "gte": week_start.strftime("%Y-%m-%d"),
-                            "lte": week_end.strftime("%Y-%m-%d")
-                        }}},
+                        {
+                            "range": {
+                                "date_utc": {
+                                    "gte": week_start.strftime("%Y-%m-%d"),
+                                    "lte": week_end.strftime("%Y-%m-%d"),
+                                }
+                            }
+                        },
                         {"term": {"report_type": "daily"}},
-                        {"term": {"sensor": "aggregate"}}
+                        {"term": {"sensor": "aggregate"}},
                     ]
                 }
             },
-            "size": 7
+            "size": 7,
         }
-        
-        response = self.es.search(
-            index="cowrie.reports.daily-*",
-            body=query
-        )
-        
+
+        response = self.es.search(index="cowrie.reports.daily-*", body=query)
+
         if not response['hits']['hits']:
             logger.warning(f"No daily reports found for week {year_week}")
             return None
-            
+
         # Aggregate the daily reports
         weekly: Dict[str, Any] = {
             "@timestamp": datetime.utcnow().isoformat() + "Z",
             "year_week": year_week,
-            "date_range": {
-                "start": week_start.strftime("%Y-%m-%d"),
-                "end": week_end.strftime("%Y-%m-%d")
-            },
+            "date_range": {"start": week_start.strftime("%Y-%m-%d"), "end": week_end.strftime("%Y-%m-%d")},
             "sensor": "aggregate",
             "report_type": "weekly",
             "generated_at": datetime.utcnow().isoformat() + "Z",
@@ -654,51 +645,47 @@ class CowrieReporter:
             "commands": defaultdict(int),
             "files": defaultdict(int),
             "enrichments": defaultdict(list),
-            "alerts_summary": []
+            "alerts_summary": [],
         }
-        
+
         # Sum up metrics from daily reports
         for hit in response['hits']['hits']:
             daily = cast(Dict[str, Any], hit['_source'])
-            
+
             # Aggregate sessions
             for key in ['total', 'unique_ips', 'unique_usernames', 'unique_passwords']:
                 if key in daily.get('sessions', {}):
                     weekly['sessions'][key] += daily['sessions'][key]
-                    
+
             # Aggregate commands
             for key in ['total', 'unique']:
                 if key in daily.get('commands', {}):
                     weekly['commands'][key] += daily['commands'][key]
-                    
+
             # Aggregate files
             for key in ['downloads_total', 'uploads_total', 'unique_hashes']:
                 if key in daily.get('files', {}):
                     weekly['files'][key] += daily['files'][key]
-                    
+
             # Collect all alerts
             if daily.get('alerts'):
                 weekly['alerts_summary'].extend(daily['alerts'])
-                
+
         # Convert defaultdicts to regular dicts
         weekly['sessions'] = dict(weekly['sessions'])
         weekly['commands'] = dict(weekly['commands'])
         weekly['files'] = dict(weekly['files'])
-        
+
         # Calculate averages
         if weekly['days_included'] > 0:
-            weekly['sessions']['daily_average'] = round(
-                weekly['sessions']['total'] / weekly['days_included'], 2
-            )
-            weekly['commands']['daily_average'] = round(
-                weekly['commands']['total'] / weekly['days_included'], 2
-            )
-            
+            weekly['sessions']['daily_average'] = round(weekly['sessions']['total'] / weekly['days_included'], 2)
+            weekly['commands']['daily_average'] = round(weekly['commands']['total'] / weekly['days_included'], 2)
+
         return weekly
-    
+
     def generate_monthly_rollup(self, year_month: str) -> Optional[Dict[str, Any]]:
         """Generate monthly rollup from daily reports.
-        
+
         Args:
             year_month: Year and month in YYYY-MM format
         Returns:
@@ -715,16 +702,20 @@ class CowrieReporter:
             "query": {
                 "bool": {
                     "filter": [
-                        {"range": {"date_utc": {
-                            "gte": month_start.strftime("%Y-%m-%d"),
-                            "lte": month_end.strftime("%Y-%m-%d")
-                        }}},
+                        {
+                            "range": {
+                                "date_utc": {
+                                    "gte": month_start.strftime("%Y-%m-%d"),
+                                    "lte": month_end.strftime("%Y-%m-%d"),
+                                }
+                            }
+                        },
                         {"term": {"report_type": "daily"}},
-                        {"term": {"sensor": "aggregate"}}
+                        {"term": {"sensor": "aggregate"}},
                     ]
                 }
             },
-            "size": 31
+            "size": 31,
         }
 
         response = self.es.search(index="cowrie.reports.daily-*", body=query)
@@ -736,10 +727,7 @@ class CowrieReporter:
         monthly: Dict[str, Any] = {
             "@timestamp": datetime.utcnow().isoformat() + "Z",
             "year_month": year_month,
-            "date_range": {
-                "start": month_start.strftime("%Y-%m-%d"),
-                "end": month_end.strftime("%Y-%m-%d")
-            },
+            "date_range": {"start": month_start.strftime("%Y-%m-%d"), "end": month_end.strftime("%Y-%m-%d")},
             "sensor": "aggregate",
             "report_type": "monthly",
             "generated_at": datetime.utcnow().isoformat() + "Z",
@@ -751,9 +739,9 @@ class CowrieReporter:
                 "unique_vt_classifications": set(),
                 "unique_urlhaus_tags": set(),
                 "unique_countries": set(),
-                "unique_asns": set()
+                "unique_asns": set(),
             },
-            "alerts_summary": defaultdict(lambda: {"count": 0, "messages": []})
+            "alerts_summary": defaultdict(lambda: {"count": 0, "messages": []}),
         }
 
         for hit in hits:
@@ -784,17 +772,15 @@ class CowrieReporter:
             for alert in daily.get('alerts', []) or []:
                 alert_type = alert.get('type', 'unknown')
                 monthly['alerts_summary'][alert_type]['count'] += 1
-                monthly['alerts_summary'][alert_type]['messages'].append({
-                    "date": daily.get('date_utc'),
-                    "message": alert.get('message'),
-                    "severity": alert.get('severity')
-                })
+                monthly['alerts_summary'][alert_type]['messages'].append(
+                    {"date": daily.get('date_utc'), "message": alert.get('message'), "severity": alert.get('severity')}
+                )
 
         monthly['enrichments'] = {
             'unique_vt_classifications': len(monthly['enrichments']['unique_vt_classifications']),
             'unique_urlhaus_tags': len(monthly['enrichments']['unique_urlhaus_tags']),
             'unique_countries': len(monthly['enrichments']['unique_countries']),
-            'unique_asns': len(monthly['enrichments']['unique_asns'])
+            'unique_asns': len(monthly['enrichments']['unique_asns']),
         }
         monthly['sessions'] = dict(monthly['sessions'])
         monthly['commands'] = dict(monthly['commands'])
@@ -802,12 +788,8 @@ class CowrieReporter:
         monthly['alerts_summary'] = dict(monthly['alerts_summary'])
 
         if monthly['days_included'] > 0:
-            monthly['sessions']['daily_average'] = round(
-                monthly['sessions']['total'] / monthly['days_included'], 2
-            )
-            monthly['commands']['daily_average'] = round(
-                monthly['commands']['total'] / monthly['days_included'], 2
-            )
+            monthly['sessions']['daily_average'] = round(monthly['sessions']['total'] / monthly['days_included'], 2)
+            monthly['commands']['daily_average'] = round(monthly['commands']['total'] / monthly['days_included'], 2)
             monthly['files']['daily_average_downloads'] = round(
                 monthly['files']['downloads_total'] / monthly['days_included'], 2
             )
@@ -823,18 +805,20 @@ class CowrieReporter:
                     "filter": [
                         {"term": {"year_month": prev_month_str}},
                         {"term": {"report_type": "monthly"}},
-                        {"term": {"sensor": "aggregate"}}
+                        {"term": {"sensor": "aggregate"}},
                     ]
                 }
             },
-            "size": 1
+            "size": 1,
         }
         prev_response = self.es.search(index="cowrie.reports.monthly-*", body=prev_query, ignore=[404])
         prev_hits = prev_response.get('hits', {}).get('hits', [])
         if prev_hits:
             prev = cast(Dict[str, Any], prev_hits[0]['_source'])
+
             def pct_change(curr, prev_val):
                 return round(((curr - prev_val) / prev_val * 100) if prev_val > 0 else 0, 2)
+
             sessions_curr = monthly['sessions'].get('total', 0)
             sessions_prev = prev.get('sessions', {}).get('total', 0)
             uniq_curr = monthly['sessions'].get('unique_ips', 0)
@@ -844,11 +828,11 @@ class CowrieReporter:
             monthly['trends'] = {
                 'sessions_change': pct_change(sessions_curr, sessions_prev),
                 'unique_ips_change': pct_change(uniq_curr, uniq_prev),
-                'files_change': pct_change(files_curr, files_prev)
+                'files_change': pct_change(files_curr, files_prev),
             }
 
         return monthly
-    
+
     def close(self):
         """Close database connections."""
         self.conn.close()
@@ -858,65 +842,69 @@ class CowrieReporter:
 def main():
     """Main entry point for the script."""
     parser = argparse.ArgumentParser(description='Generate Elasticsearch reports from Cowrie data')
-    
+
     # Database options
-    parser.add_argument('--db', default='../cowrieprocessor.sqlite',
-                        help='Path to SQLite database')
-    
+    parser.add_argument('--db', default='../cowrieprocessor.sqlite', help='Path to SQLite database')
+
     # Elasticsearch options
     parser.add_argument('--es-host', help='Elasticsearch host URL')
     parser.add_argument('--es-username', help='Elasticsearch username')
     parser.add_argument('--es-password', help='Elasticsearch password')
     parser.add_argument('--es-api-key', help='Elasticsearch API key')
     parser.add_argument('--es-cloud-id', help='Elastic Cloud ID')
-    parser.add_argument('--no-ssl-verify', action='store_true',
-                        help='Disable SSL certificate verification')
-    
+    parser.add_argument('--no-ssl-verify', action='store_true', help='Disable SSL certificate verification')
+
     # Report options
     parser.add_argument('--sensor', help='Sensor name (default: hostname)')
-    parser.add_argument('--top-n', type=int, default=10,
-                        help='Number of top items to include (default: 10)')
-    parser.add_argument('--vt-recent-days', type=int, default=5,
-                        help='Days to consider VT submission recent (default: 5)')
-    
+    parser.add_argument('--top-n', type=int, default=10, help='Number of top items to include (default: 10)')
+    parser.add_argument(
+        '--vt-recent-days', type=int, default=5, help='Days to consider VT submission recent (default: 5)'
+    )
+
     # Commands
     subparsers = parser.add_subparsers(dest='command', help='Command to run')
-    
+
     # Daily report command
     daily_parser = subparsers.add_parser('daily', help='Generate daily report')
-    daily_parser.add_argument('--date', default=datetime.utcnow().strftime('%Y-%m-%d'),
-                              help='Date to process (YYYY-MM-DD)')
-    daily_parser.add_argument('--all-sensors', action='store_true',
-                              help='Generate reports for all sensors')
-    
+    daily_parser.add_argument(
+        '--date', default=datetime.utcnow().strftime('%Y-%m-%d'), help='Date to process (YYYY-MM-DD)'
+    )
+    daily_parser.add_argument('--all-sensors', action='store_true', help='Generate reports for all sensors')
+
     # Backfill command
     backfill_parser = subparsers.add_parser('backfill', help='Backfill reports for date range')
-    backfill_parser.add_argument('--start', required=True,
-                                  help='Start date (YYYY-MM-DD)')
-    backfill_parser.add_argument('--end', required=True,
-                                  help='End date (YYYY-MM-DD)')
-    backfill_parser.add_argument('--sensors', nargs='*',
-                                  help='Specific sensors to process')
-    
+    backfill_parser.add_argument('--start', required=True, help='Start date (YYYY-MM-DD)')
+    backfill_parser.add_argument('--end', required=True, help='End date (YYYY-MM-DD)')
+    backfill_parser.add_argument('--sensors', nargs='*', help='Specific sensors to process')
+
     # Weekly rollup command
     weekly_parser = subparsers.add_parser('weekly', help='Generate weekly rollup')
-    weekly_parser.add_argument('--week', 
-                                default=datetime.utcnow().strftime('%Y-W%U'),
-                                help='Week to process (YYYY-Www)')
-    
+    weekly_parser.add_argument(
+        '--week', default=datetime.utcnow().strftime('%Y-W%U'), help='Week to process (YYYY-Www)'
+    )
+
     # Monthly rollup command
     monthly_parser = subparsers.add_parser('monthly', help='Generate monthly rollup')
-    monthly_parser.add_argument('--month', 
-                                default=datetime.utcnow().strftime('%Y-%m'),
-                                help='Month to process (YYYY-MM)')
-    
+    monthly_parser.add_argument(
+        '--month', default=datetime.utcnow().strftime('%Y-%m'), help='Month to process (YYYY-MM)'
+    )
+
     args = parser.parse_args()
-    
+
     # Get ES credentials from environment if not provided
     es_host = args.es_host or os.getenv('ES_HOST')
     es_username = args.es_username or os.getenv('ES_USERNAME')
     es_password = args.es_password or os.getenv('ES_PASSWORD')
     es_api_key = args.es_api_key or os.getenv('ES_API_KEY')
+    # Resolve secret references if provided via env/args
+    try:
+        if is_reference(es_password):
+            es_password = resolve_secret(es_password)
+        if is_reference(es_api_key):
+            es_api_key = resolve_secret(es_api_key)
+    except Exception:
+        # Keep silent on resolution failure; fallback to raw value
+        pass
     es_cloud_id = args.es_cloud_id or os.getenv('ES_CLOUD_ID')
     # SSL verify from env (ES_VERIFY_SSL=false to disable)
     env_verify = os.getenv('ES_VERIFY_SSL')
@@ -925,11 +913,11 @@ def main():
         verify_ssl = False
     elif env_verify is not None and env_verify.lower() in ('false', '0', 'no'):
         verify_ssl = False
-    
+
     if not (es_host or es_cloud_id):
         logger.error("Either ES_HOST or ES_CLOUD_ID must be provided")
         sys.exit(1)
-        
+
     # Create reporter
     reporter = CowrieReporter(
         db_path=args.db,
@@ -941,9 +929,9 @@ def main():
         es_verify_ssl=verify_ssl,
         sensor_name=args.sensor,
         top_n=args.top_n,
-        vt_recent_days=args.vt_recent_days
+        vt_recent_days=args.vt_recent_days,
     )
-    
+
     try:
         if args.command == 'daily':
             if args.all_sensors:
@@ -952,7 +940,7 @@ def main():
                 cur.execute("SELECT DISTINCT hostname FROM sessions WHERE hostname IS NOT NULL")
                 sensors = [row['hostname'] for row in cur.fetchall()]
                 cur.close()
-                
+
                 # Generate reports for each sensor plus aggregate
                 for s in sensors:
                     report = reporter.generate_daily_report(args.date, s)
@@ -965,10 +953,10 @@ def main():
                 report = reporter.generate_daily_report(args.date, args.sensor)
                 reporter.index_report(report)
                 print(json.dumps(report, indent=2))
-                
+
         elif args.command == 'backfill':
             reporter.backfill_daily(args.start, args.end, args.sensors)
-            
+
         elif args.command == 'weekly':
             report = reporter.generate_weekly_rollup(args.week)
             if report:
@@ -983,10 +971,10 @@ def main():
                 print(json.dumps(report, indent=2))
             else:
                 logger.error("Failed to generate monthly rollup")
-                
+
         else:
             parser.print_help()
-            
+
     finally:
         reporter.close()
 

--- a/process_cowrie.py
+++ b/process_cowrie.py
@@ -27,6 +27,8 @@ from pathlib import Path
 import dropbox
 import requests
 
+from secrets_resolver import is_reference, resolve_secret
+
 # Default logs directory (can be overridden later via --log-dir)
 default_logs_dir = Path('/mnt/dshield/data/logs')
 try:
@@ -39,7 +41,7 @@ basic_with_time_format = '%(asctime)s:%(levelname)s:%(name)s:%(filename)s:%(func
 logging_fhandler.setFormatter(logging.Formatter(basic_with_time_format))
 logging_fhandler.setLevel(logging.ERROR)
 
-stdout_handler = logging.StreamHandler(stream = sys.stdout)
+stdout_handler = logging.StreamHandler(stream=sys.stdout)
 stdout_handler.setFormatter(logging.Formatter(basic_with_time_format))
 stdout_handler.setLevel(logging.DEBUG)
 
@@ -49,105 +51,173 @@ logging.root.setLevel(logging.DEBUG)
 
 date = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S")
 
-parser = argparse.ArgumentParser(
-    description='DShield Honeypot Cowrie Data Identifiers'
-)
+parser = argparse.ArgumentParser(description='DShield Honeypot Cowrie Data Identifiers')
 parser.add_argument(
-    '--logpath', dest='logpath', type=str,
+    '--logpath',
+    dest='logpath',
+    type=str,
     help='Path of cowrie json log files',
     default='/srv/cowrie/var/log/cowrie',
 )
 parser.add_argument(
-    '--ttyfile', dest='ttyfile', type=str,
+    '--ttyfile',
+    dest='ttyfile',
+    type=str,
     help='Name of TTY associated TTY log file',
 )
 parser.add_argument(
-    '--downloadfile', dest='downloadfile', type=str,
+    '--downloadfile',
+    dest='downloadfile',
+    type=str,
     help='Name of downloaded file (matches file SHA-256 hash)',
 )
 parser.add_argument(
-    '--session', dest='session', type=str,
+    '--session',
+    dest='session',
+    type=str,
     help='Cowrie session number',
 )
 parser.add_argument(
-    '--vtapi', dest='vtapi', type=str,
+    '--vtapi',
+    dest='vtapi',
+    type=str,
     help='VirusTotal API key (required for VT data lookup)',
 )
 parser.add_argument(
-    '--email', dest='email', type=str,
+    '--email',
+    dest='email',
+    type=str,
     help='Your email address (required for DShield IP lookup)',
 )
 parser.add_argument(
-    '--summarizedays', dest='summarizedays', type=str,
+    '--summarizedays',
+    dest='summarizedays',
+    type=str,
     help='Will summarize all attacks in the give number of days',
 )
 parser.add_argument(
-    '--dbxapi', dest='dbxapi', type=str,
+    '--dbxapi',
+    dest='dbxapi',
+    type=str,
     help='Dropbox access token for use with Dropbox upload of summary text files',
 )
 parser.add_argument(
-    '--dbxkey', dest='dbxkey', type=str,
+    '--dbxkey',
+    dest='dbxkey',
+    type=str,
     help='Dropbox app key to be used to get new short-lived API access key',
 )
 parser.add_argument(
-    '--dbxsecret', dest='dbxsecret', type=str,
+    '--dbxsecret',
+    dest='dbxsecret',
+    type=str,
     help='Dropbox app secret to be used to get new short-lived API access key',
 )
 parser.add_argument(
-    '--dbxrefreshtoken', dest='dbxrefreshtoken', type=str,
+    '--dbxrefreshtoken',
+    dest='dbxrefreshtoken',
+    type=str,
     help='Dropbox refresh token to be used to get new short-lived API access key',
 )
 parser.add_argument(
-    '--spurapi', dest='spurapi', type=str,
+    '--spurapi',
+    dest='spurapi',
+    type=str,
     help='SPUR.us API key to be used for SPUR.us data encrichment',
 )
 parser.add_argument(
-    '--urlhausapi', dest='urlhausapi', type=str,
+    '--urlhausapi',
+    dest='urlhausapi',
+    type=str,
     help='URLhaus API key for URLhaus data enrichment',
 )
-parser.add_argument('--data-dir', dest='data_dir', type=str,
-    default='/mnt/dshield/data', help='Base directory for data: cache/temp/logs (default: /mnt/dshield/data)')
-parser.add_argument('--cache-dir', dest='cache_dir', type=str,
-    help='Cache directory (default: <data-dir>/cache/cowrieprocessor)')
-parser.add_argument('--temp-dir', dest='temp_dir', type=str,
-    help='Temp directory (default: <data-dir>/temp/cowrieprocessor)')
-parser.add_argument('--log-dir', dest='log_dir', type=str,
-    help='Logs directory (default: <data-dir>/logs)')
-parser.add_argument('--bulk-load', dest='bulk_load', action='store_true',
-    help='Enable SQLite bulk load mode (defer commits, relaxed PRAGMAs)')
-parser.add_argument('--buffer-bytes', dest='buffer_bytes', type=int, default=1048576,
-    help='Read buffer size in bytes for compressed log files (default: 1048576)')
- 
-parser.add_argument('--api-timeout', dest='api_timeout', type=int, default=15,
-    help='HTTP timeout in seconds for external APIs (default: 15)')
-parser.add_argument('--api-retries', dest='api_retries', type=int, default=3,
-    help='Max retries for transient API failures (default: 3)')
-parser.add_argument('--api-backoff', dest='api_backoff', type=float, default=2.0,
-    help='Exponential backoff base in seconds (default: 2.0)')
-parser.add_argument('--hash-ttl-days', dest='hash_ttl_days', type=int, default=30,
-    help='TTL in days for file hash lookups (default: 30)')
-parser.add_argument('--hash-unknown-ttl-hours', dest='hash_unknown_ttl_hours', type=int, default=12,
-    help='TTL in hours to recheck VT for unknown hashes sooner (default: 12)')
-parser.add_argument('--ip-ttl-hours', dest='ip_ttl_hours', type=int, default=12,
-    help='TTL in hours for IP lookups (default: 12)')
-parser.add_argument('--rate-vt', dest='rate_vt', type=int, default=4,
-    help='Max VirusTotal requests per minute (default: 4)')
-parser.add_argument('--rate-dshield', dest='rate_dshield', type=int, default=30,
-    help='Max DShield requests per minute (default: 30)')
-parser.add_argument('--rate-urlhaus', dest='rate_urlhaus', type=int, default=30,
-    help='Max URLhaus requests per minute (default: 30)')
-parser.add_argument('--rate-spur', dest='rate_spur', type=int, default=30,
-    help='Max SPUR requests per minute (default: 30)')
 parser.add_argument(
-    '--output-dir', dest='output_dir', type=str,
-    help='Base directory for reports and caches (default: <logpath>/../reports)'
+    '--data-dir',
+    dest='data_dir',
+    type=str,
+    default='/mnt/dshield/data',
+    help='Base directory for data: cache/temp/logs (default: /mnt/dshield/data)',
 )
 parser.add_argument(
-    '--sensor', dest='sensor', type=str,
-    help='Sensor name/hostname to tag data with (defaults to system hostname)'
+    '--cache-dir', dest='cache_dir', type=str, help='Cache directory (default: <data-dir>/cache/cowrieprocessor)'
 )
 parser.add_argument(
-    '--db', dest='db', type=str,
+    '--temp-dir', dest='temp_dir', type=str, help='Temp directory (default: <data-dir>/temp/cowrieprocessor)'
+)
+parser.add_argument('--log-dir', dest='log_dir', type=str, help='Logs directory (default: <data-dir>/logs)')
+parser.add_argument(
+    '--bulk-load',
+    dest='bulk_load',
+    action='store_true',
+    help='Enable SQLite bulk load mode (defer commits, relaxed PRAGMAs)',
+)
+parser.add_argument(
+    '--buffer-bytes',
+    dest='buffer_bytes',
+    type=int,
+    default=1048576,
+    help='Read buffer size in bytes for compressed log files (default: 1048576)',
+)
+
+parser.add_argument(
+    '--api-timeout',
+    dest='api_timeout',
+    type=int,
+    default=15,
+    help='HTTP timeout in seconds for external APIs (default: 15)',
+)
+parser.add_argument(
+    '--api-retries', dest='api_retries', type=int, default=3, help='Max retries for transient API failures (default: 3)'
+)
+parser.add_argument(
+    '--api-backoff',
+    dest='api_backoff',
+    type=float,
+    default=2.0,
+    help='Exponential backoff base in seconds (default: 2.0)',
+)
+parser.add_argument(
+    '--hash-ttl-days',
+    dest='hash_ttl_days',
+    type=int,
+    default=30,
+    help='TTL in days for file hash lookups (default: 30)',
+)
+parser.add_argument(
+    '--hash-unknown-ttl-hours',
+    dest='hash_unknown_ttl_hours',
+    type=int,
+    default=12,
+    help='TTL in hours to recheck VT for unknown hashes sooner (default: 12)',
+)
+parser.add_argument(
+    '--ip-ttl-hours', dest='ip_ttl_hours', type=int, default=12, help='TTL in hours for IP lookups (default: 12)'
+)
+parser.add_argument(
+    '--rate-vt', dest='rate_vt', type=int, default=4, help='Max VirusTotal requests per minute (default: 4)'
+)
+parser.add_argument(
+    '--rate-dshield', dest='rate_dshield', type=int, default=30, help='Max DShield requests per minute (default: 30)'
+)
+parser.add_argument(
+    '--rate-urlhaus', dest='rate_urlhaus', type=int, default=30, help='Max URLhaus requests per minute (default: 30)'
+)
+parser.add_argument(
+    '--rate-spur', dest='rate_spur', type=int, default=30, help='Max SPUR requests per minute (default: 30)'
+)
+parser.add_argument(
+    '--output-dir',
+    dest='output_dir',
+    type=str,
+    help='Base directory for reports and caches (default: <logpath>/../reports)',
+)
+parser.add_argument(
+    '--sensor', dest='sensor', type=str, help='Sensor name/hostname to tag data with (defaults to system hostname)'
+)
+parser.add_argument(
+    '--db',
+    dest='db',
+    type=str,
     help='Path to central SQLite database',
     default='../cowrieprocessor.sqlite',
 )
@@ -158,15 +228,26 @@ log_location = args.logpath
 tty_file = args.ttyfile
 download_file = args.downloadfile
 session_id = args.session
-vtapi = args.vtapi
-email = args.email
+vtapi = args.vtapi or os.getenv('VT_API_KEY')
+email = args.email or os.getenv('DSHIELD_EMAIL')
 summarizedays = args.summarizedays
-dbxapi = args.dbxapi
-dbxkey = args.dbxkey
-dbxsecret = args.dbxsecret
-dbxrefreshtoken = args.dbxrefreshtoken
-spurapi = args.spurapi
-urlhausapi = args.urlhausapi
+dbxapi = args.dbxapi or os.getenv('DROPBOX_ACCESS_TOKEN')
+dbxkey = args.dbxkey or os.getenv('DROPBOX_APP_KEY')
+dbxsecret = args.dbxsecret or os.getenv('DROPBOX_APP_SECRET')
+dbxrefreshtoken = args.dbxrefreshtoken or os.getenv('DROPBOX_REFRESH_TOKEN')
+spurapi = args.spurapi or os.getenv('SPUR_API_KEY')
+urlhausapi = args.urlhausapi or os.getenv('URLHAUS_API_KEY')
+
+# Resolve secret references if provided directly
+try:
+    for name in ["vtapi", "email", "dbxapi", "dbxkey", "dbxsecret", "dbxrefreshtoken", "spurapi", "urlhausapi"]:
+        val = locals().get(name)
+        if is_reference(val):
+            locals()[name] = resolve_secret(val)
+            globals()[name] = locals()[name]
+except Exception:
+    # Non-fatal; continue with raw values if resolution failed
+    pass
 
 api_timeout = args.api_timeout if hasattr(args, 'api_timeout') else 15
 api_retries = args.api_retries if hasattr(args, 'api_retries') else 3
@@ -183,6 +264,7 @@ rate_limits = {
 
 last_request_time = {k: 0.0 for k in rate_limits.keys()}
 
+
 def rate_limit(service):
     """Simple per-service rate limiter based on requests per minute."""
     now = time.time()
@@ -194,6 +276,7 @@ def rate_limit(service):
     if elapsed < min_interval:
         time.sleep(min_interval - elapsed)
     last_request_time[service] = time.time()
+
 
 def cache_get(service, key):
     """Fetch (last_fetched, data) for a service/key from indicator_cache."""
@@ -213,6 +296,7 @@ def cache_upsert(service, key, data):
     )
     db_commit()
 
+
 # string prepended to filename for report summaries
 # may want a '_' at the start of this string for readability
 hostname = args.sensor if args.sensor else socket.gethostname()
@@ -230,7 +314,7 @@ for d in (cache_dir, temp_dir):
 
 # Determine output directory: configurable or derived from log path
 try:
-    default_base = (Path(log_location).parent / 'reports')
+    default_base = Path(log_location).parent / 'reports'
 except Exception:
     default_base = Path.cwd() / 'reports'
 base_output_dir = Path(args.output_dir) if getattr(args, 'output_dir', None) else default_base
@@ -250,6 +334,7 @@ _last_status_ts = 0.0
 _last_state = ""
 _last_file = ""
 
+
 def write_status(state: str, total_files: int, processed_files: int, current_file: str = "", **extra):
     """Write JSON status to the status file at most every status_interval seconds.
 
@@ -257,6 +342,7 @@ def write_status(state: str, total_files: int, processed_files: int, current_fil
     into the payload (e.g., file_lines, elapsed_secs).
     """
     import json as _json
+
     global _last_status_ts, _last_state, _last_file
     now = time.time()
     # Write immediately if state or current_file changed; otherwise throttle
@@ -285,6 +371,7 @@ def write_status(state: str, total_files: int, processed_files: int, current_fil
     except Exception:
         # Non-fatal
         pass
+
 
 data = []
 attack_count = 0
@@ -320,9 +407,10 @@ if bulk_load:
         con.execute('PRAGMA synchronous=OFF')
         con.execute('PRAGMA temp_store=MEMORY')
         con.execute('PRAGMA cache_size=-200000')  # ~200MB cache
-        con.execute('PRAGMA mmap_size=268435456') # 256MB if supported
+        con.execute('PRAGMA mmap_size=268435456')  # 256MB if supported
     except Exception:
         logging.warning("Failed to set some bulk-load PRAGMAs", exc_info=True)
+
 
 def db_commit():
     """Commit the SQLite transaction unless in bulk-load mode.
@@ -335,6 +423,7 @@ def db_commit():
             con.commit()
     except Exception:
         logging.error("Commit failed", exc_info=True)
+
 
 def initialize_database():
     """Create and evolve the local SQLite schema if needed.
@@ -431,7 +520,7 @@ def initialize_database():
         logging.info("Hostname columns likely already exist...")
 
     try:
-        #add new columns for spur data in preexisting databases
+        # add new columns for spur data in preexisting databases
         cur.execute('''ALTER TABLE sessions ADD spur_asn text''')
         cur.execute('''ALTER TABLE sessions ADD spur_asn_organization text''')
         cur.execute('''ALTER TABLE sessions ADD spur_organization text''')
@@ -449,7 +538,7 @@ def initialize_database():
         cur.execute('''ALTER TABLE sessions ADD spur_tunnel_anonymous text''')
         cur.execute('''ALTER TABLE sessions ADD spur_tunnel_entries text''')
         cur.execute('''ALTER TABLE sessions ADD spur_tunnel_operator text''')
-        cur.execute('''ALTER TABLE sessions ADD spur_tunnel_type text''')        
+        cur.execute('''ALTER TABLE sessions ADD spur_tunnel_type text''')
         cur.execute('''ALTER TABLE files ADD spur_asn text''')
         cur.execute('''ALTER TABLE files ADD spur_asn_organization text''')
         cur.execute('''ALTER TABLE files ADD spur_organization text''')
@@ -468,31 +557,31 @@ def initialize_database():
         cur.execute('''ALTER TABLE files ADD spur_tunnel_entries text''')
         cur.execute('''ALTER TABLE files ADD spur_tunnel_operator text''')
         cur.execute('''ALTER TABLE files ADD spur_tunnel_type text''')
-        db_commit()        
+        db_commit()
     except Exception:
         print("Failure adding table columns, likely because they already exist...")
 
     try:
-        #add new columns for spur data in preexisting databases
+        # add new columns for spur data in preexisting databases
         cur.execute('''ALTER TABLE sessions ADD spur_tunnel_anonymous text''')
         cur.execute('''ALTER TABLE sessions ADD spur_tunnel_entries text''')
         cur.execute('''ALTER TABLE sessions ADD spur_tunnel_operator text''')
-        cur.execute('''ALTER TABLE sessions ADD spur_tunnel_type text''')      
-        cur.execute('''ALTER TABLE sessions ADD spur_client_proxies text''')  
+        cur.execute('''ALTER TABLE sessions ADD spur_tunnel_type text''')
+        cur.execute('''ALTER TABLE sessions ADD spur_client_proxies text''')
         cur.execute('''ALTER TABLE files ADD spur_tunnel_anonymous text''')
         cur.execute('''ALTER TABLE files ADD spur_tunnel_entries text''')
         cur.execute('''ALTER TABLE files ADD spur_tunnel_operator text''')
         cur.execute('''ALTER TABLE files ADD spur_tunnel_type text''')
         cur.execute('''ALTER TABLE files ADD spur_client_proxies text''')
-        db_commit()        
+        db_commit()
     except Exception:
         logging.error("Failure adding table columns, likely because they already exist...")
     try:
-        #add new columns for spur data in preexisting databases
+        # add new columns for spur data in preexisting databases
         cur.execute('''ALTER TABLE sessions ADD session_duration int''')
-        db_commit()        
+        db_commit()
     except Exception:
-        logging.error("Failure adding table columns, likely because they already exist...")        
+        logging.error("Failure adding table columns, likely because they already exist...")
     # Create helpful indexes to speed reporting queries
     try:
         cur.execute('''CREATE INDEX IF NOT EXISTS idx_sessions_hostname_ts ON sessions(hostname, timestamp)''')
@@ -519,6 +608,7 @@ def initialize_database():
     except Exception:
         logging.error("Failure creating indicator_cache table")
 
+
 def get_connected_sessions(data):
     """Return unique session IDs that successfully authenticated.
 
@@ -531,9 +621,10 @@ def get_connected_sessions(data):
     logging.info("Extracting unique sessions...")
     sessions = set()
     for each_entry in data:
-        if each_entry['eventid'] == "cowrie.login.success": 
+        if each_entry['eventid'] == "cowrie.login.success":
             sessions.add(each_entry['session'])
     return sessions
+
 
 def get_session_id(data, type, match):
     """Identify sessions by artifact type.
@@ -549,25 +640,26 @@ def get_session_id(data, type, match):
     """
     logging.info("Extracting unique sessions")
     sessions = set()
-    if (type == "tty"):
+    if type == "tty":
         for each_entry in data:
-            if ("ttylog" in each_entry):
-                if each_entry['ttylog'] == ("var/lib/cowrie/tty/" + match): 
+            if "ttylog" in each_entry:
+                if each_entry['ttylog'] == ("var/lib/cowrie/tty/" + match):
                     sessions.add(each_entry['session'])
-    elif (type == "download"):
+    elif type == "download":
         for each_entry in data:
-            if ("shasum" in each_entry):
-                if each_entry['shasum'] == match: 
+            if "shasum" in each_entry:
+                if each_entry['shasum'] == match:
                     sessions.add(each_entry['session'])
-    elif (type == "all"):
+    elif type == "all":
         for each_entry in data:
-            if ("shasum" in each_entry):
-                if ("src_ip" in each_entry):
+            if "shasum" in each_entry:
+                if "src_ip" in each_entry:
                     sessions.add(each_entry['session'])
-            if ("ttylog" in each_entry):
-                if ("src_ip" in each_entry):
+            if "ttylog" in each_entry:
+                if "src_ip" in each_entry:
                     sessions.add(each_entry['session'])
     return sessions
+
 
 def get_session_duration(session, data):
     """Return the session duration in seconds, if present.
@@ -589,6 +681,7 @@ def get_session_duration(session, data):
 
     return duration
 
+
 def get_protocol_login(session, data):
     """Return the network protocol for a session.
 
@@ -604,6 +697,7 @@ def get_protocol_login(session, data):
         if each_entry['session'] == session:
             if each_entry['eventid'] == "cowrie.session.connect":
                 return each_entry['protocol']
+
 
 def get_login_data(session, data):
     """Extract login details for a session.
@@ -621,6 +715,7 @@ def get_login_data(session, data):
             if each_entry['eventid'] == "cowrie.login.success":
                 return each_entry['username'], each_entry['password'], each_entry['timestamp'], each_entry['src_ip']
 
+
 def get_command_total(session, data):
     """Count commands executed in a session.
 
@@ -637,6 +732,7 @@ def get_command_total(session, data):
             if "cowrie.command." in each_entry['eventid']:
                 count += 1
     return count
+
 
 def get_file_download(session, data):
     """Collect file download events for a session.
@@ -664,15 +760,14 @@ def get_file_download(session, data):
                             each_entry['url'],
                         )[0]
                     except Exception:
-                        download_ip = re.findall(
-                            r"\:\/\/(.*?)\/", each_entry['url']
-                        )[0]
+                        download_ip = re.findall(r"\:\/\/(.*?)\/", each_entry['url'])[0]
                 if "shasum" in each_entry:
                     shasum = each_entry['shasum']
                 if "destfile" in each_entry:
                     destfile = each_entry['destfile']
                 returndata.append([url, shasum, download_ip, destfile])
     return returndata
+
 
 def get_file_upload(session, data):
     """Collect file upload events for a session.
@@ -700,16 +795,15 @@ def get_file_upload(session, data):
                             each_entry['url'],
                         )[0]
                     except Exception:
-                        upload_ip = re.findall(
-                            r"\:\/\/(.*?)\/", each_entry['url']
-                        )[0]
+                        upload_ip = re.findall(r"\:\/\/(.*?)\/", each_entry['url'])[0]
                 if "shasum" in each_entry:
                     shasum = each_entry['shasum']
                 if "filename" in each_entry:
                     destfile = each_entry['filename']
                 returndata.append([url, shasum, upload_ip, destfile])
-    #vt_filescan(shasum)
+    # vt_filescan(shasum)
     return returndata
+
 
 def vt_query(hash, cache_dir: Path):
     """Query VirusTotal for a file hash and write the JSON response.
@@ -740,7 +834,9 @@ def vt_query(hash, cache_dir: Path):
                 with open(vt_path, 'w') as f:
                     f.write(data)
             return
-    vt_session.headers = {'X-Apikey': vtapi}
+    if not vtapi:
+        return
+    vt_session.headers.update({'X-Apikey': vtapi})
     url = "https://www.virustotal.com/api/v3/files/" + hash
     attempt = 0
     while attempt < api_retries:
@@ -767,6 +863,7 @@ def vt_query(hash, cache_dir: Path):
             time.sleep(api_backoff * attempt)
     logging.error(f"VT query failed for {hash} after retries")
 
+
 def vt_filescan(hash, cache_dir: Path):
     """Upload a local file to VirusTotal for scanning.
 
@@ -777,6 +874,9 @@ def vt_filescan(hash, cache_dir: Path):
     Returns:
         None. Side effects: writes ``files_<hash>`` with the response.
     """
+    if not vtapi:
+        logging.error("VT filescan requested without VT API key")
+        return
     headers = {'X-Apikey': vtapi}
     url = "https://www.virustotal.com/api/v3/files"
     attempt = 0
@@ -797,6 +897,7 @@ def vt_filescan(hash, cache_dir: Path):
             except Exception:
                 time.sleep(api_backoff * attempt)
     logging.error(f"VT filescan failed for {hash}")
+
 
 def dshield_query(ip_address):
     """Query DShield for information about an IP address.
@@ -833,6 +934,7 @@ def dshield_query(ip_address):
     logging.error(f"DShield query failed for {ip_address}")
     return {"ip": {"asname": "", "ascountry": ""}}
 
+
 def uh_query(ip_address, uh_api):
     """Query URLHaus for information about a host and cache the result.
 
@@ -858,7 +960,6 @@ def uh_query(ip_address, uh_api):
     while attempt < api_retries:
         attempt += 1
         try:
-
             rate_limit('urlhaus')
             response = uh_session.post(url, headers=uh_header, data=host, timeout=api_timeout)
             if response.status_code == 429:
@@ -874,6 +975,7 @@ def uh_query(ip_address, uh_api):
             print("Exception hit for URLHaus query")
             time.sleep(api_backoff * attempt)
     logging.error(f"URLHaus query failed for {ip_address}")
+
 
 def read_uh_data(ip_address, urlhausapi):
     """Read locally cached URLHaus data and return a tag summary.
@@ -900,7 +1002,7 @@ def read_uh_data(ip_address, urlhausapi):
     tags = set()
     try:
         for eachurl in json_data['urls']:
-            if (eachurl['tags']):
+            if eachurl['tags']:
                 for eachtag in eachurl['tags']:
                     tags.add(eachtag)
     except Exception:
@@ -921,22 +1023,20 @@ def read_vt_data(hash, cache_dir: Path):
     Returns:
         Tuple ``(description, classification, first_submission, malicious)``.
     """
-    hash_info = open(cache_dir / hash,'r')
+    hash_info = open(cache_dir / hash, 'r')
     file = ""
     for each_time in hash_info:
         file += each_time
     hash_info.close
     json_data = json.loads(file)
-    
+
     try:
         vt_description = json_data['data']['attributes']['type_description']
     except Exception:
         vt_description = ""
 
     try:
-        vt_threat_classification = json_data['data']['attributes'][
-            'popular_threat_classification'
-        ][
+        vt_threat_classification = json_data['data']['attributes']['popular_threat_classification'][
             'suggested_threat_label'
         ]
     except Exception:
@@ -952,6 +1052,7 @@ def read_vt_data(hash, cache_dir: Path):
 
     return vt_description, vt_threat_classification, vt_first_submission, vt_malicious
 
+
 def spur_query(ip_address):
     """Query SPUR.us for an IP context and cache the JSON response.
 
@@ -962,7 +1063,7 @@ def spur_query(ip_address):
         None. Side effects: writes ``spur_<ip>.json`` to disk.
     """
     spur_session.headers = {'Token': spurapi}
-    #token = {'Token': api_spur}
+    # token = {'Token': api_spur}
     url = "https://api.spur.us/v2/context/" + ip_address
     # Use cache if fresh
     cached = cache_get('spur_ip', ip_address)
@@ -992,6 +1093,7 @@ def spur_query(ip_address):
             time.sleep(api_backoff * attempt)
     logging.error(f"SPUR query failed for {ip_address}")
 
+
 def read_spur_data(ip_address):
     """Read cached SPUR.us data and return normalized fields.
 
@@ -1011,7 +1113,7 @@ def read_spur_data(ip_address):
     spur_path = cache_dir / ("spur_" + ip_address.replace(":", "_") + ".json")
     if not spur_path.exists():
         spur_query(ip_address)
-    spur_data = open(spur_path, 'r',encoding="utf-8")
+    spur_data = open(spur_path, 'r', encoding="utf-8")
     file = ""
     for eachline in spur_data:
         file += eachline
@@ -1019,60 +1121,60 @@ def read_spur_data(ip_address):
     json_data = json.loads(file)
 
     spur_list = []
-    if ("as" in json_data):
-        if ("number" in json_data['as']):
+    if "as" in json_data:
+        if "number" in json_data['as']:
             as_number = json_data['as']['number']
         else:
             as_number = ""
         spur_list.append(as_number)
 
-        if ("organization" in json_data['as']):
-            as_organization = json_data['as']['organization']       
+        if "organization" in json_data['as']:
+            as_organization = json_data['as']['organization']
         else:
-            as_organization = ""    
+            as_organization = ""
         spur_list.append(as_organization)
 
-    if ("organization" in json_data):
+    if "organization" in json_data:
         organization = json_data['organization']
     else:
         organization = ""
     spur_list.append(organization)
 
-    if ("infrastructure" in json_data):
+    if "infrastructure" in json_data:
         infrastructure = json_data['infrastructure']
     else:
         infrastructure = ""
     spur_list.append(infrastructure)
 
-    if ("client" in json_data):
-        if ("behaviors" in json_data['client']):
+    if "client" in json_data:
+        if "behaviors" in json_data['client']:
             client_behaviors = json_data['client']['behaviors']
         else:
             client_behaviors = ""
-        if ("proxies" in json_data['client']):
+        if "proxies" in json_data['client']:
             client_proxies = json_data['client']['proxies']
         else:
             client_proxies = ""
-        if ("types" in json_data['client']):
+        if "types" in json_data['client']:
             client_types = json_data['client']['types']
         else:
             client_types = ""
-        if ("count" in json_data['client']):
+        if "count" in json_data['client']:
             client_count = str(json_data['client']['count'])
         else:
             client_count = ""
-        if ("concentration" in json_data['client']):
+        if "concentration" in json_data['client']:
             client_concentration = json_data['client']['concentration']
         else:
             client_concentration = ""
-        if ("countries" in json_data['client']):
+        if "countries" in json_data['client']:
             client_countries = json_data['client']['countries']
         else:
             client_countries = ""
-        if ("spread" in json_data['client']):
-            client_spread = json_data['client']['spread']     
+        if "spread" in json_data['client']:
+            client_spread = json_data['client']['spread']
         else:
-            client_spread = ""  
+            client_spread = ""
     else:
         client_behaviors = ""
         client_proxies = ""
@@ -1089,48 +1191,48 @@ def read_spur_data(ip_address):
     spur_list.append(client_countries)
     spur_list.append(client_spread)
 
-    if ("risks" in json_data):
+    if "risks" in json_data:
         risks = json_data['risks']
     else:
         risks = ""
     spur_list.append(risks)
 
-    if ("services" in json_data):
+    if "services" in json_data:
         services = json_data['services']
     else:
         services = ""
     spur_list.append(services)
 
-    if ("location" in json_data):
+    if "location" in json_data:
         city = ""
         state = ""
         country = ""
-        if ("city" in json_data['location']):
+        if "city" in json_data['location']:
             city = json_data['location']['city'] + ", "
-        if ("state" in json_data['location']):
+        if "state" in json_data['location']:
             state = json_data['location']['state'] + ", "
-        if ("country" in json_data['location']):
+        if "country" in json_data['location']:
             country = json_data['location']['country']
         location = city + state + country
     else:
         location = ""
     spur_list.append(location)
 
-    if ("tunnels" in json_data):
+    if "tunnels" in json_data:
         for each_tunnel in json_data['tunnels']:
-            if ("anonymous" in each_tunnel):
+            if "anonymous" in each_tunnel:
                 tunnel_anonymous = each_tunnel['anonymous']
             else:
                 tunnel_anonymous = ""
-            if ("entries" in each_tunnel):
+            if "entries" in each_tunnel:
                 tunnel_entries = each_tunnel['entries']
             else:
                 tunnel_entries = ""
-            if ("operator" in each_tunnel):
+            if "operator" in each_tunnel:
                 tunnel_operator = each_tunnel['operator']
             else:
                 tunnel_operator = ""
-            if ("type" in each_tunnel):
+            if "type" in each_tunnel:
                 tunnel_type = each_tunnel['type']
             else:
                 tunnel_type = ""
@@ -1143,7 +1245,7 @@ def read_spur_data(ip_address):
     spur_list.append(tunnel_entries)
     spur_list.append(tunnel_operator)
     spur_list.append(tunnel_type)
-    
+
     return spur_list
 
 
@@ -1169,8 +1271,8 @@ def print_session_info(data, sessions, attack_type):
         protocol = get_protocol_login(session, data)
         session_duration = get_session_duration(session, data)
 
-        #try block for partially available data
-        #this is usually needed due to an attack spanning multiple log files not included for processing
+        # try block for partially available data
+        # this is usually needed due to an attack spanning multiple log files not included for processing
         try:
             username, password, timestamp, src_ip = get_login_data(session, data)
         except Exception:
@@ -1182,129 +1284,118 @@ def print_session_info(data, sessions, attack_type):
         downloaddata = get_file_download(session, data)
         uploaddata = get_file_upload(session, data)
 
-        attackstring = "{:>30s}  {:50s}".format("Session",str(session)) + "\n"
-        attackstring += "{:>30s}  {:50s}".format("Session Duration",str(session_duration)[0:5] + " seconds") + "\n"
-        attackstring += "{:>30s}  {:50s}".format("Protocol",str(protocol)) + "\n"
-        attackstring += "{:>30s}  {:50s}".format("Username",str(username)) + "\n"
-        attackstring += "{:>30s}  {:50s}".format("Password",str(password)) + "\n"
-        attackstring += "{:>30s}  {:50s}".format("Timestamp",str(timestamp)) + "\n"
-        attackstring += "{:>30s}  {:50s}".format("Source IP Address",str(src_ip)) + "\n"
+        attackstring = "{:>30s}  {:50s}".format("Session", str(session)) + "\n"
+        attackstring += "{:>30s}  {:50s}".format("Session Duration", str(session_duration)[0:5] + " seconds") + "\n"
+        attackstring += "{:>30s}  {:50s}".format("Protocol", str(protocol)) + "\n"
+        attackstring += "{:>30s}  {:50s}".format("Username", str(username)) + "\n"
+        attackstring += "{:>30s}  {:50s}".format("Password", str(password)) + "\n"
+        attackstring += "{:>30s}  {:50s}".format("Timestamp", str(timestamp)) + "\n"
+        attackstring += "{:>30s}  {:50s}".format("Source IP Address", str(src_ip)) + "\n"
 
         if urlhausapi:
-            attackstring += "{:>30s}  {:50s}".format("URLhaus IP Tags",str(read_uh_data(src_ip, urlhausapi))) + "\n"
+            attackstring += "{:>30s}  {:50s}".format("URLhaus IP Tags", str(read_uh_data(src_ip, urlhausapi))) + "\n"
 
-        if(email):
+        if email:
             json_data = dshield_query(src_ip)
-            attackstring += "{:>30s}  {:50s}".format("ASNAME",(json_data['ip']['asname'])) + "\n"
-            attackstring += "{:>30s}  {:50s}".format("ASCOUNTRY",(json_data['ip']['ascountry'])) + "\n"
-            attackstring += "{:>30s}  {:<6d}".format("Total Commands Run",command_count) + "\n"
+            attackstring += "{:>30s}  {:50s}".format("ASNAME", (json_data['ip']['asname'])) + "\n"
+            attackstring += "{:>30s}  {:50s}".format("ASCOUNTRY", (json_data['ip']['ascountry'])) + "\n"
+            attackstring += "{:>30s}  {:<6d}".format("Total Commands Run", command_count) + "\n"
 
-        if(spurapi):
+        if spurapi:
             spur_session_data = read_spur_data(src_ip)
             if spur_session_data[0] != "":
                 attackstring += "{:>30s}  {:<50s}".format("SPUR ASN", str(spur_session_data[0])) + "\n"
             if spur_session_data[1] != "":
                 attackstring += "{:>30s}  {:<50s}".format("SPUR ASN Organization", str(spur_session_data[1])) + "\n"
             if spur_session_data[2] != "":
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Organization", str(spur_session_data[2])) + "\n"     
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Organization", str(spur_session_data[2])) + "\n"
             if spur_session_data[3] != "":
-                attackstring += (
-                    "{:>30s}  {:<50s}".format(
-                        "SPUR Infrastructure", str(spur_session_data[3])
-                    )
-                    + "\n"
-                )
-            if spur_session_data[4] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Behaviors", str(spur_session_data[4])) + "\n"  
-            if spur_session_data[5] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Proxies", str(spur_session_data[5])) + "\n"  
-            if spur_session_data[6] != "":               
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Types", str(spur_session_data[6])) + "\n"  
-            if spur_session_data[7] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Count", str(spur_session_data[7])) + "\n"  
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Infrastructure", str(spur_session_data[3])) + "\n"
+            if spur_session_data[4] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Behaviors", str(spur_session_data[4])) + "\n"
+            if spur_session_data[5] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Proxies", str(spur_session_data[5])) + "\n"
+            if spur_session_data[6] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Types", str(spur_session_data[6])) + "\n"
+            if spur_session_data[7] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Count", str(spur_session_data[7])) + "\n"
             if spur_session_data[8] != "":
-                attackstring += (
-                    "{:>30s}  {:<50s}".format(
-                        "SPUR Client Concentration", str(spur_session_data[8])
-                    )
-                    + "\n"
-                )
-            if spur_session_data[9] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Countries", str(spur_session_data[9])) + "\n"    
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Concentration", str(spur_session_data[8])) + "\n"
+            if spur_session_data[9] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Countries", str(spur_session_data[9])) + "\n"
             if spur_session_data[10] != "":
-                attackstring += (
-                    "{:>30s}  {:<50s}".format(
-                        "SPUR Client Geo-spread", str(spur_session_data[10])
-                    )
-                    + "\n"
-                )
-            if spur_session_data[11] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Risks", str(spur_session_data[11])) + "\n"  
-            if spur_session_data[12] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Services", str(spur_session_data[12])) + "\n"  
-            if spur_session_data[13] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Location", str(spur_session_data[13])) + "\n"  
-            if spur_session_data[14] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Anonymous Tunnel", str(spur_session_data[14])) + "\n"   
-            if spur_session_data[15] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Tunnel Entries", str(spur_session_data[15])) + "\n"  
-            if spur_session_data[16] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Tunnel Operator", str(spur_session_data[16])) + "\n"  
-            if spur_session_data[17] != "":                
-                attackstring += "{:>30s}  {:<50s}".format("SPUR Tunnel Type", str(spur_session_data[17])) + "\n"  
-
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Geo-spread", str(spur_session_data[10])) + "\n"
+            if spur_session_data[11] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Risks", str(spur_session_data[11])) + "\n"
+            if spur_session_data[12] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Services", str(spur_session_data[12])) + "\n"
+            if spur_session_data[13] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Location", str(spur_session_data[13])) + "\n"
+            if spur_session_data[14] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Anonymous Tunnel", str(spur_session_data[14])) + "\n"
+            if spur_session_data[15] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Tunnel Entries", str(spur_session_data[15])) + "\n"
+            if spur_session_data[16] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Tunnel Operator", str(spur_session_data[16])) + "\n"
+            if spur_session_data[17] != "":
+                attackstring += "{:>30s}  {:<50s}".format("SPUR Tunnel Type", str(spur_session_data[17])) + "\n"
 
         if len(downloaddata) > 0:
             attackstring += "\n------------------- DOWNLOAD DATA -------------------\n"
         for each_download in downloaddata:
-            if(each_download[1]):
+            if each_download[1]:
                 attackstring += "\n"
-                attackstring += "{:>30s}  {:50s}".format("Download URL",each_download[0]) + "\n"
-                attackstring += "{:>30s}  {:50s}".format("Download SHA-256 Hash",each_download[1]) + "\n"
-                attackstring += "{:>30s}  {:50s}".format("Destination File",each_download[3]) + "\n"
+                attackstring += "{:>30s}  {:50s}".format("Download URL", each_download[0]) + "\n"
+                attackstring += "{:>30s}  {:50s}".format("Download SHA-256 Hash", each_download[1]) + "\n"
+                attackstring += "{:>30s}  {:50s}".format("Destination File", each_download[3]) + "\n"
 
                 sql = '''SELECT * FROM files WHERE session=? and hash=? and file_path=? and hostname=?'''
                 cur.execute(sql, (session, each_download[1], each_download[3], hostname))
                 rows = cur.fetchall()
                 download_data_needed = len(rows)
 
-                if(download_data_needed > 0):
+                if download_data_needed > 0:
                     print("Download data for session " + session + " was already stored within database")
                 else:
                     sql = '''INSERT INTO files(session, download_url, hash, file_path, hostname) VALUES (?,?,?,?,?)'''
                     cur.execute(sql, (session, each_download[0], each_download[1], each_download[3], hostname))
                     db_commit()
 
-
-                vt_cache_path = (cache_dir / each_download[1])
-                if (not vt_cache_path.exists() and vtapi):
+                vt_cache_path = cache_dir / each_download[1]
+                if not vt_cache_path.exists() and vtapi:
                     vt_query(each_download[1], cache_dir)
                     time.sleep(15)
 
-                if (vt_cache_path.exists() and vtapi):
+                if vt_cache_path.exists() and vtapi:
                     vt_description, vt_threat_classification, vt_first_submission, vt_malicious = read_vt_data(
                         each_download[1], cache_dir
                     )
+                    attackstring += "{:>30s}  {:50s}".format("VT Description", (vt_description)) + "\n"
                     attackstring += (
-                        "{:>30s}  {:50s}".format("VT Description", (vt_description))
-                        + "\n"
+                        "{:>30s}  {:50s}".format("VT Threat Classification", (vt_threat_classification)) + "\n"
                     )
-                    attackstring += (
-                        "{:>30s}  {:50s}".format(
-                            "VT Threat Classification", (vt_threat_classification)
-                        )
-                        + "\n"
-                    )
-                    if(download_data_needed == 0):
+                    if download_data_needed == 0:
                         sql = '''UPDATE files SET vt_description=?, vt_threat_classification=?, vt_first_submission=?, 
                             vt_hits=?, transfer_method=?, added=? WHERE session=? and hash=? and hostname=?'''
-                        cur.execute(sql, (vt_description, vt_threat_classification, vt_first_submission, vt_malicious,
-                            "DOWNLOAD", time.time(), session, each_download[1], hostname))
+                        cur.execute(
+                            sql,
+                            (
+                                vt_description,
+                                vt_threat_classification,
+                                vt_first_submission,
+                                vt_malicious,
+                                "DOWNLOAD",
+                                time.time(),
+                                session,
+                                each_download[1],
+                                hostname,
+                            ),
+                        )
                         db_commit()
                     if vt_threat_classification == "":
-                        vt_classifications.append("<blank>") 
-                        #commented out due to too many inclusions from hosts.deny data
-                        #abnormal_attacks.add(session)
+                        vt_classifications.append("<blank>")
+                        # commented out due to too many inclusions from hosts.deny data
+                        # abnormal_attacks.add(session)
                     else:
                         vt_classifications.append(vt_threat_classification)
                     attackstring += (
@@ -1317,14 +1408,11 @@ def print_session_info(data, sessions, attack_type):
                     if (datetime.datetime.now() - datetime.datetime.fromtimestamp(int(vt_first_submission))).days <= 5:
                         abnormal_attacks.add(session)
                         vt_recent_submissions.add(session)
-                    attackstring += "{:>30s}  {:<6d}".format("VT Malicious Hits",(vt_malicious)) + "\n"
+                    attackstring += "{:>30s}  {:<6d}".format("VT Malicious Hits", (vt_malicious)) + "\n"
 
-                if (each_download[2] != "" and email):
-                    if (re.search('[a-zA-Z]', each_download[2])):
-
-                        attackstring += "{:>30s}  {:50s}".format(
-                            "Download Source Address", each_download[2]
-                        ) + "\n"
+                if each_download[2] != "" and email:
+                    if re.search('[a-zA-Z]', each_download[2]):
+                        attackstring += "{:>30s}  {:50s}".format("Download Source Address", each_download[2]) + "\n"
                         if urlhausapi:
                             attackstring += (
                                 "{:>30s}  {:50s}".format(
@@ -1346,133 +1434,74 @@ def print_session_info(data, sessions, attack_type):
                         db_commit()
                     else:
                         json_data = dshield_query(each_download[2])
-                        attackstring += "{:>30s}  {:50s}".format(
-                            "Download Source Address", each_download[2]
-                        ) + "\n"
+                        attackstring += "{:>30s}  {:50s}".format("Download Source Address", each_download[2]) + "\n"
                         if urlhausapi:
                             attackstring += (
-                                "{:>30s}  {:50s}".format(
-                                    "URLhaus IP Tags", read_uh_data(each_download[2], urlhausapi)
-                                )
+                                "{:>30s}  {:50s}".format("URLhaus IP Tags", read_uh_data(each_download[2], urlhausapi))
                                 + "\n"
                             )
-                        attackstring += "{:>30s}  {:50s}".format("ASNAME",(json_data['ip']['asname'])) + "\n"
-                        attackstring += "{:>30s}  {:50s}".format("ASCOUNTRY",(json_data['ip']['ascountry'])) + "\n"
+                        attackstring += "{:>30s}  {:50s}".format("ASNAME", (json_data['ip']['asname'])) + "\n"
+                        attackstring += "{:>30s}  {:50s}".format("ASCOUNTRY", (json_data['ip']['ascountry'])) + "\n"
 
-                        if(spurapi):
+                        if spurapi:
                             spur_data = read_spur_data(src_ip)
                             if spur_data[0] != "":
                                 attackstring += "{:>30s}  {:<50s}".format("SPUR ASN", str(spur_data[0])) + "\n"
                             if spur_data[1] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR ASN Organization", str(spur_data[1])
-                                    )
-                                    + "\n"
+                                    "{:>30s}  {:<50s}".format("SPUR ASN Organization", str(spur_data[1])) + "\n"
                                 )
                             if spur_data[2] != "":
-                                attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Organization", str(spur_data[2])
-                                    )
-                                    + "\n"
-                                )     
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Organization", str(spur_data[2])) + "\n"
                             if spur_data[3] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Infrastructure", str(spur_data[3])
-                                    )
-                                    + "\n"
-                                )      
+                                    "{:>30s}  {:<50s}".format("SPUR Infrastructure", str(spur_data[3])) + "\n"
+                                )
                             if spur_data[4] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Behaviors", str(spur_data[4])
-                                    )
-                                    + "\n"
-                                )  
+                                    "{:>30s}  {:<50s}".format("SPUR Client Behaviors", str(spur_data[4])) + "\n"
+                                )
                             if spur_data[5] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Proxies", str(spur_data[5])
-                                    )
-                                    + "\n"
-                                )  
+                                    "{:>30s}  {:<50s}".format("SPUR Client Proxies", str(spur_data[5])) + "\n"
+                                )
                             if spur_data[6] != "":
-                                attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Types", str(spur_data[6])
-                                    )
-                                    + "\n"
-                                )  
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Types", str(spur_data[6])) + "\n"
                             if spur_data[7] != "":
-                                attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Count", str(spur_data[7])
-                                    )
-                                    + "\n"
-                                )  
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Count", str(spur_data[7])) + "\n"
                             if spur_data[8] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Concentration", str(spur_data[8])
-                                    )
-                                    + "\n"
-                                )  
+                                    "{:>30s}  {:<50s}".format("SPUR Client Concentration", str(spur_data[8])) + "\n"
+                                )
                             if spur_data[9] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Countries", str(spur_data[9])
-                                    )
-                                    + "\n"
-                                )    
+                                    "{:>30s}  {:<50s}".format("SPUR Client Countries", str(spur_data[9])) + "\n"
+                                )
                             if spur_data[10] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Geo-spread", str(spur_data[10])
-                                    )
-                                    + "\n"
-                                )    
-                            if spur_data[11] != "":                
-                                attackstring += "{:>30s}  {:<50s}".format("SPUR Risks", str(spur_data[11])) + "\n"  
-                            if spur_data[12] != "":                
-                                attackstring += "{:>30s}  {:<50s}".format("SPUR Services", str(spur_data[12])) + "\n"  
-                            if spur_data[13] != "":
-                                attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Location", str(spur_data[13])
-                                    )
-                                    + "\n"
+                                    "{:>30s}  {:<50s}".format("SPUR Client Geo-spread", str(spur_data[10])) + "\n"
                                 )
+                            if spur_data[11] != "":
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Risks", str(spur_data[11])) + "\n"
+                            if spur_data[12] != "":
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Services", str(spur_data[12])) + "\n"
+                            if spur_data[13] != "":
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Location", str(spur_data[13])) + "\n"
                             if spur_data[14] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Anonymous Tunnel", str(spur_data[14])
-                                    )
-                                    + "\n"
-                                )   
+                                    "{:>30s}  {:<50s}".format("SPUR Anonymous Tunnel", str(spur_data[14])) + "\n"
+                                )
                             if spur_data[15] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Tunnel Entries", str(spur_data[15])
-                                    )
-                                    + "\n"
-                                )  
+                                    "{:>30s}  {:<50s}".format("SPUR Tunnel Entries", str(spur_data[15])) + "\n"
+                                )
                             if spur_data[16] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Tunnel Operator", str(spur_data[16])
-                                    )
-                                    + "\n"
-                                )  
+                                    "{:>30s}  {:<50s}".format("SPUR Tunnel Operator", str(spur_data[16])) + "\n"
+                                )
                             if spur_data[17] != "":
-                                attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Tunnel Type", str(spur_data[17])
-                                    )
-                                    + "\n"
-                                )  
-                        
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Tunnel Type", str(spur_data[17])) + "\n"
+
                             sql = '''UPDATE files SET src_ip=?, urlhaus_tag=?, asname=?, ascountry=?,
                                 spur_asn=?,
                                 spur_asn_organization=?,
@@ -1529,42 +1558,36 @@ def print_session_info(data, sessions, attack_type):
         if len(uploaddata) > 0:
             attackstring += "\n------------------- UPLOAD DATA -------------------\n"
         for each_upload in uploaddata:
-            if(each_upload[1]):
+            if each_upload[1]:
                 attackstring += "\n"
-                attackstring += "{:>30s}  {:50s}".format("Upload URL",each_upload[0]) + "\n"
-                attackstring += "{:>30s}  {:50s}".format("Upload SHA-256 Hash",each_upload[1]) + "\n"
-                attackstring += "{:>30s}  {:50s}".format("Destination File",each_upload[3]) + "\n"
+                attackstring += "{:>30s}  {:50s}".format("Upload URL", each_upload[0]) + "\n"
+                attackstring += "{:>30s}  {:50s}".format("Upload SHA-256 Hash", each_upload[1]) + "\n"
+                attackstring += "{:>30s}  {:50s}".format("Destination File", each_upload[3]) + "\n"
 
                 sql = '''SELECT * FROM files WHERE session=? and hash=? and file_path=? and hostname=?'''
                 cur.execute(sql, (session, each_upload[1], each_upload[3], hostname))
                 rows = cur.fetchall()
                 upload_data_needed = len(rows)
 
-                if(upload_data_needed > 0):
+                if upload_data_needed > 0:
                     print("Upload data for session " + session + " was already stored within database")
                 else:
                     sql = '''INSERT INTO files(session, download_url, hash, file_path, hostname) VALUES (?,?,?,?,?)'''
                     cur.execute(sql, (session, each_upload[0], each_upload[1], each_upload[3], hostname))
                     db_commit()
 
-                up_vt_cache_path = (cache_dir / each_upload[1])
-                if (not up_vt_cache_path.exists() and vtapi):
+                up_vt_cache_path = cache_dir / each_upload[1]
+                if not up_vt_cache_path.exists() and vtapi:
                     vt_query(each_upload[1], cache_dir)
                     time.sleep(15)
 
-                if (up_vt_cache_path.exists() and vtapi):
+                if up_vt_cache_path.exists() and vtapi:
                     vt_description, vt_threat_classification, vt_first_submission, vt_malicious = read_vt_data(
                         each_upload[1], cache_dir
                     )
+                    attackstring += "{:>30s}  {:50s}".format("VT Description", (vt_description)) + "\n"
                     attackstring += (
-                        "{:>30s}  {:50s}".format("VT Description", (vt_description))
-                        + "\n"
-                    )
-                    attackstring += (
-                        "{:>30s}  {:50s}".format(
-                            "VT Threat Classification", (vt_threat_classification)
-                        )
-                        + "\n"
+                        "{:>30s}  {:50s}".format("VT Threat Classification", (vt_threat_classification)) + "\n"
                     )
                     attackstring += (
                         "{:>30s}  {}".format(
@@ -1573,26 +1596,33 @@ def print_session_info(data, sessions, attack_type):
                         )
                         + "\n"
                     )
-                    attackstring += "{:>30s}  {:<6d}".format("VT Malicious Hits",(vt_malicious)) + "\n"
+                    attackstring += "{:>30s}  {:<6d}".format("VT Malicious Hits", (vt_malicious)) + "\n"
 
-                    if(upload_data_needed == 0):
+                    if upload_data_needed == 0:
                         sql = '''UPDATE files SET vt_description=?, vt_threat_classification=?, vt_first_submission=?,
                             vt_hits=?, transfer_method=?, added=? WHERE session=? and hash=? and hostname=?'''
-                        cur.execute(sql, (vt_description, vt_threat_classification, vt_first_submission, vt_malicious,
-                            "UPLOAD", time.time(), session, each_upload[1], hostname))
+                        cur.execute(
+                            sql,
+                            (
+                                vt_description,
+                                vt_threat_classification,
+                                vt_first_submission,
+                                vt_malicious,
+                                "UPLOAD",
+                                time.time(),
+                                session,
+                                each_upload[1],
+                                hostname,
+                            ),
+                        )
                         db_commit()
 
-                if (each_upload[2] != "" and email):
-                    if (re.search('[a-zA-Z]', each_upload[2])):
-
-                        attackstring += "{:>30s}  {:50s}".format(
-                            "Upload Source Address", each_upload[2]
-                        ) + "\n"
+                if each_upload[2] != "" and email:
+                    if re.search('[a-zA-Z]', each_upload[2]):
+                        attackstring += "{:>30s}  {:50s}".format("Upload Source Address", each_upload[2]) + "\n"
                         if urlhausapi:
                             attackstring += (
-                                "{:>30s}  {:50s}".format(
-                                    "URLhaus IP Tags", read_uh_data(each_upload[2], urlhausapi)
-                                )
+                                "{:>30s}  {:50s}".format("URLhaus IP Tags", read_uh_data(each_upload[2], urlhausapi))
                                 + "\n"
                             )
 
@@ -1611,133 +1641,73 @@ def print_session_info(data, sessions, attack_type):
 
                     else:
                         json_data = dshield_query(each_upload[2])
-                        attackstring += "{:>30s}  {:50s}".format(
-                            "Upload Source Address", each_upload[2]
-                        ) + "\n"
+                        attackstring += "{:>30s}  {:50s}".format("Upload Source Address", each_upload[2]) + "\n"
                         if urlhausapi:
                             attackstring += (
-                                "{:>30s}  {:50s}".format(
-                                    "URLhaus IP Tags", read_uh_data(each_upload[2], urlhausapi)
-                                )
+                                "{:>30s}  {:50s}".format("URLhaus IP Tags", read_uh_data(each_upload[2], urlhausapi))
                                 + "\n"
                             )
-                        attackstring += "{:>30s}  {:50s}".format("ASNAME",(json_data['ip']['asname'])) + "\n"
-                        attackstring += "{:>30s}  {:50s}".format("ASCOUNTRY",(json_data['ip']['ascountry'])) + "\n"
+                        attackstring += "{:>30s}  {:50s}".format("ASNAME", (json_data['ip']['asname'])) + "\n"
+                        attackstring += "{:>30s}  {:50s}".format("ASCOUNTRY", (json_data['ip']['ascountry'])) + "\n"
 
-
-                        if(spurapi):
+                        if spurapi:
                             spur_data = read_spur_data(src_ip)
                             if spur_data[0] != "":
                                 attackstring += "{:>30s}  {:<50s}".format("SPUR ASN", str(spur_data[0])) + "\n"
                             if spur_data[1] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR ASN Organization", str(spur_data[1])
-                                    )
-                                    + "\n"
+                                    "{:>30s}  {:<50s}".format("SPUR ASN Organization", str(spur_data[1])) + "\n"
                                 )
                             if spur_data[2] != "":
-                                attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Organization", str(spur_data[2])
-                                    )
-                                    + "\n"
-                                )     
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Organization", str(spur_data[2])) + "\n"
                             if spur_data[3] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Infrastructure", str(spur_data[3])
-                                    )
-                                    + "\n"
+                                    "{:>30s}  {:<50s}".format("SPUR Infrastructure", str(spur_data[3])) + "\n"
                                 )
                             if spur_data[4] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Behaviors", str(spur_data[4])
-                                    )
-                                    + "\n"
-                                )  
+                                    "{:>30s}  {:<50s}".format("SPUR Client Behaviors", str(spur_data[4])) + "\n"
+                                )
                             if spur_data[5] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Proxies", str(spur_data[5])
-                                    )
-                                    + "\n"
-                                )  
+                                    "{:>30s}  {:<50s}".format("SPUR Client Proxies", str(spur_data[5])) + "\n"
+                                )
                             if spur_data[6] != "":
-                                attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Types", str(spur_data[6])
-                                    )
-                                    + "\n"
-                                )  
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Types", str(spur_data[6])) + "\n"
                             if spur_data[7] != "":
-                                attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Count", str(spur_data[7])
-                                    )
-                                    + "\n"
-                                )  
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Client Count", str(spur_data[7])) + "\n"
                             if spur_data[8] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Concentration", str(spur_data[8])
-                                    )
-                                    + "\n"
+                                    "{:>30s}  {:<50s}".format("SPUR Client Concentration", str(spur_data[8])) + "\n"
                                 )
                             if spur_data[9] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Countries", str(spur_data[9])
-                                    )
-                                    + "\n"
-                                )    
+                                    "{:>30s}  {:<50s}".format("SPUR Client Countries", str(spur_data[9])) + "\n"
+                                )
                             if spur_data[10] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Client Geo-spread", str(spur_data[10])
-                                    )
-                                    + "\n"
+                                    "{:>30s}  {:<50s}".format("SPUR Client Geo-spread", str(spur_data[10])) + "\n"
                                 )
-                            if spur_data[11] != "":                
-                                attackstring += "{:>30s}  {:<50s}".format("SPUR Risks", str(spur_data[11])) + "\n"  
-                            if spur_data[12] != "":                
-                                attackstring += "{:>30s}  {:<50s}".format("SPUR Services", str(spur_data[12])) + "\n"  
+                            if spur_data[11] != "":
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Risks", str(spur_data[11])) + "\n"
+                            if spur_data[12] != "":
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Services", str(spur_data[12])) + "\n"
                             if spur_data[13] != "":
-                                attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Location", str(spur_data[13])
-                                    )
-                                    + "\n"
-                                )  
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Location", str(spur_data[13])) + "\n"
                             if spur_data[14] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Anonymous Tunnel", str(spur_data[14])
-                                    )
-                                    + "\n"
-                                )   
+                                    "{:>30s}  {:<50s}".format("SPUR Anonymous Tunnel", str(spur_data[14])) + "\n"
+                                )
                             if spur_data[15] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Tunnel Entries", str(spur_data[15])
-                                    )
-                                    + "\n"
-                                )  
+                                    "{:>30s}  {:<50s}".format("SPUR Tunnel Entries", str(spur_data[15])) + "\n"
+                                )
                             if spur_data[16] != "":
                                 attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Tunnel Operator", str(spur_data[16])
-                                    )
-                                    + "\n"
-                                )  
+                                    "{:>30s}  {:<50s}".format("SPUR Tunnel Operator", str(spur_data[16])) + "\n"
+                                )
                             if spur_data[17] != "":
-                                attackstring += (
-                                    "{:>30s}  {:<50s}".format(
-                                        "SPUR Tunnel Type", str(spur_data[17])
-                                    )
-                                    + "\n"
-                                )                           
+                                attackstring += "{:>30s}  {:<50s}".format("SPUR Tunnel Type", str(spur_data[17])) + "\n"
 
                             sql = '''UPDATE files SET src_ip=?, urlhaus_tag=?, asname=?, ascountry=?,
                                 spur_asn=?,
@@ -1792,7 +1762,6 @@ def print_session_info(data, sessions, attack_type):
                             )
                             db_commit()
 
-
         attackstring += "\n////////////////// COMMANDS ATTEMPTED //////////////////\n\n"
         attackstring += get_commands(data, session) + "\n"
         attackstring += (
@@ -1807,7 +1776,7 @@ def print_session_info(data, sessions, attack_type):
         cur.execute(sql, (session, epoch_time, hostname))
 
         rows = cur.fetchall()
-        if (len(rows) > 0):
+        if len(rows) > 0:
             print("Data for session " + session + " was already stored within database")
         else:
             sql = (
@@ -1815,9 +1784,8 @@ def print_session_info(data, sessions, attack_type):
                 "timestamp, source_ip, urlhaus_tag, asname, ascountry, total_commands, added, hostname) "
                 "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)"
             )
-            
-            if 'json_data' in locals():
 
+            if 'json_data' in locals():
                 cur.execute(
                     sql,
                     (
@@ -1858,7 +1826,7 @@ def print_session_info(data, sessions, attack_type):
                 )
                 db_commit()
 
-            if(spurapi):
+            if spurapi:
                 sql = '''UPDATE sessions SET 
                     spur_asn=?,
                     spur_asn_organization=?,
@@ -1879,42 +1847,49 @@ def print_session_info(data, sessions, attack_type):
                     spur_tunnel_operator=?,
                     spur_tunnel_type=?                             
                     WHERE session=? and timestamp=? and hostname=?'''
-                cur.execute(sql, (str(spur_session_data[0]),
-                                    str(spur_session_data[1]),
-                                    str(spur_session_data[2]),
-                                    str(spur_session_data[3]),
-                                    str(spur_session_data[4]),
-                                    str(spur_session_data[5]),
-                                    str(spur_session_data[6]),
-                                    str(spur_session_data[7]),
-                                    str(spur_session_data[8]),
-                                    str(spur_session_data[9]),
-                                    str(spur_session_data[10]),
-                                    str(spur_session_data[11]),
-                                    str(spur_session_data[12]),
-                                    str(spur_session_data[13]),
-                                    str(spur_session_data[14]),
-                                    str(spur_session_data[15]),
-                                    str(spur_session_data[16]),
-                                    str(spur_session_data[17]),
-                                    session, epoch_time, hostname))
+                cur.execute(
+                    sql,
+                    (
+                        str(spur_session_data[0]),
+                        str(spur_session_data[1]),
+                        str(spur_session_data[2]),
+                        str(spur_session_data[3]),
+                        str(spur_session_data[4]),
+                        str(spur_session_data[5]),
+                        str(spur_session_data[6]),
+                        str(spur_session_data[7]),
+                        str(spur_session_data[8]),
+                        str(spur_session_data[9]),
+                        str(spur_session_data[10]),
+                        str(spur_session_data[11]),
+                        str(spur_session_data[12]),
+                        str(spur_session_data[13]),
+                        str(spur_session_data[14]),
+                        str(spur_session_data[15]),
+                        str(spur_session_data[16]),
+                        str(spur_session_data[17]),
+                        session,
+                        epoch_time,
+                        hostname,
+                    ),
+                )
                 db_commit()
 
-
-        if (attack_type == "abnormal"):
-            if (summarizedays):
-                report_file = open(date + "_abnormal_" + summarizedays + "-day_report.txt","a", encoding="utf-8")
+        if attack_type == "abnormal":
+            if summarizedays:
+                report_file = open(date + "_abnormal_" + summarizedays + "-day_report.txt", "a", encoding="utf-8")
             else:
-                report_file = open(date + "abnormal_report.txt","a", encoding="utf-8")
+                report_file = open(date + "abnormal_report.txt", "a", encoding="utf-8")
             report_file.write(attackstring)
             report_file.close()
         else:
-            if (summarizedays):
-                report_file = open(date + "_" + summarizedays + "_day_report.txt","a", encoding="utf-8")
+            if summarizedays:
+                report_file = open(date + "_" + summarizedays + "_day_report.txt", "a", encoding="utf-8")
             else:
-                report_file = open(date + "_report.txt","a", encoding="utf-8")
+                report_file = open(date + "_report.txt", "a", encoding="utf-8")
             report_file.write(attackstring)
             report_file.close()
+
 
 def print_summary():
     """Legacy no-op summary function retained for compatibility.
@@ -1924,6 +1899,7 @@ def print_summary():
     nothing.
     """
     return None
+
 
 def get_commands(data, session):
     """Collect input commands for a session and persist them.
@@ -1946,44 +1922,44 @@ def get_commands(data, session):
                 sql = '''SELECT * FROM commands WHERE session=? and command=? and timestamp=? and hostname=?'''
                 cur.execute(sql, (session, each_entry['input'], epoch_time, hostname))
                 rows = cur.fetchall()
-                if (len(rows) > 0):
+                if len(rows) > 0:
                     print("Command data for session " + session + " was already stored within database")
                 else:
                     sql = '''INSERT INTO commands(session, command, timestamp, added, hostname) VALUES (?,?,?,?,?)'''
-                    #utc_time = datetime.datetime.strptime(each_entry['timestamp'], "%Y-%m-%dT%H:%M:%S.%fZ")
-                    #epoch_time = (utc_time - datetime.datetime(1970, 1, 1)).total_seconds()
+                    # utc_time = datetime.datetime.strptime(each_entry['timestamp'], "%Y-%m-%dT%H:%M:%S.%fZ")
+                    # epoch_time = (utc_time - datetime.datetime(1970, 1, 1)).total_seconds()
                     cur.execute(sql, (session, each_entry['input'], epoch_time, time.time(), hostname))
     db_commit()
     return commands
+
 
 initialize_database()
 
 if len(list_of_files) == 0:
     quit()
 
-if (summarizedays):
+if summarizedays:
     days = int(summarizedays)
     print("Days to summarize: " + str(days))
     file_list = []
     i = 0
-    while (len(list_of_files) > 0 and (i < days)):
-        if (i < days):
+    while len(list_of_files) > 0 and (i < days):
+        if i < days:
             file_list.append(list_of_files.pop())
         i += 1
     list_of_files = file_list
 
+
 def open_json_lines(path: str):
     """Open a JSONL file (supports .bz2 and .gz) for text reading."""
-    bufsize = int(getattr(args, 'buffer_bytes', 1048576))
     if path.endswith('.bz2'):
         bz2_raw = bz2.BZ2File(path, 'rb')
-        bz2_buf = io.BufferedReader(bz2_raw, buffer_size=bufsize)
-        return io.TextIOWrapper(bz2_buf, encoding='utf-8', errors='replace')
+        return io.TextIOWrapper(bz2_raw, encoding='utf-8', errors='replace')
     if path.endswith('.gz'):
         gz_raw = gzip.GzipFile(filename=path, mode='rb')
-        gz_buf = io.BufferedReader(gz_raw, buffer_size=bufsize)
-        return io.TextIOWrapper(gz_buf, encoding='utf-8', errors='replace')
+        return io.TextIOWrapper(gz_raw, encoding='utf-8', errors='replace')
     return open(path, 'r', encoding='utf-8', errors='replace')
+
 
 for filename in list_of_files:
     file_path_obj = Path(log_location) / filename
@@ -2004,13 +1980,16 @@ for filename in list_of_files:
                 line_count += 1
                 # heartbeat during large files
                 if (time.time() - t_last) >= max(5, status_interval):
-                    write_status(state='reading', total_files=total_files, processed_files=processed_files,
-                                 current_file=filename, file_lines=line_count)
+                    write_status(
+                        state='reading',
+                        total_files=total_files,
+                        processed_files=processed_files,
+                        current_file=filename,
+                        file_lines=line_count,
+                    )
                     t_last = time.time()
     except EOFError:
-        logging.warning(
-            f"Compressed file appears truncated; skipping: {filepath_str}"
-        )
+        logging.warning(f"Compressed file appears truncated; skipping: {filepath_str}")
         processed_files += 1
         write_status(state='reading', total_files=total_files, processed_files=processed_files, current_file=filename)
         continue
@@ -2030,23 +2009,23 @@ dshield_session = requests.session()
 uh_session = requests.session()
 spur_session = requests.session()
 
-if (summarizedays):
+if summarizedays:
     session_id = get_session_id(data, "all", "unnecessary")
     print_session_info(data, session_id, "standard")
 
-elif (session_id):
+elif session_id:
     sessions = [session_id]
     print_session_info(data, sessions, "standard")
 
-elif (tty_file):
+elif tty_file:
     session_id = get_session_id(data, "tty", tty_file)
     print_session_info(data, session_id, "standard")
 
-elif (download_file):
+elif download_file:
     session_id = get_session_id(data, "download", download_file)
     print_session_info(data, session_id, "standard")
 
-else:    
+else:
     session_id = get_session_id(data, "all", "unnecessary")
     print_session_info(data, session_id, "standard")
 
@@ -2060,15 +2039,15 @@ for num_count in number_of_commands:
 command_number_dict = {}
 abnormal_command_counts = []
 for command in commands:
-    #number of commands --> command
-    #number of times the number of commands has been seen --> number_of_commands.count(command)
+    # number of commands --> command
+    # number of times the number of commands has been seen --> number_of_commands.count(command)
     command_number_dict[command] = number_of_commands.count(command)
 
 sorted_command_counts = sorted(command_number_dict.items(), key=lambda x: x[1])
 for key, value in sorted_command_counts:
     abnormal_command_counts.append(key)
 
-abnormal_command_counts = abnormal_command_counts[0:int(len(abnormal_command_counts)*(2/3))]
+abnormal_command_counts = abnormal_command_counts[0 : int(len(abnormal_command_counts) * (2 / 3))]
 
 
 vt_counts = collections.Counter(vt_classifications)
@@ -2078,42 +2057,40 @@ for classification in vt_classifications:
     vt_class.add(classification)
 
 
-
-if (summarizedays):
+if summarizedays:
     for each_session in session_id:
         command_count = get_command_total(each_session, data)
-        #if command_count != number_of_commands[0]:
+        # if command_count != number_of_commands[0]:
         if command_count in abnormal_command_counts:
             abnormal_attacks.add(each_session)
             uncommon_command_counts.add(each_session)
 
 
-elif (session_id):
+elif session_id:
     sessions = [session_id]
     for each_session in sessions:
         command_count = get_command_total(each_session, data)
-        #if command_count != number_of_commands[0]:
+        # if command_count != number_of_commands[0]:
         if command_count in abnormal_command_counts:
             abnormal_attacks.add(each_session)
             uncommon_command_counts.add(each_session)
 
-elif (tty_file):
+elif tty_file:
     for each_session in session_id:
         command_count = get_command_total(each_session, data)
-        #if command_count != number_of_commands[0]:
+        # if command_count != number_of_commands[0]:
         if command_count in abnormal_command_counts:
             abnormal_attacks.add(each_session)
             uncommon_command_counts.add(each_session)
 
 
-elif (download_file):
+elif download_file:
     for each_session in session_id:
         command_count = get_command_total(each_session, data)
-        #if command_count != number_of_commands[0]:
+        # if command_count != number_of_commands[0]:
         if command_count in abnormal_command_counts:
             abnormal_attacks.add(each_session)
             uncommon_command_counts.add(each_session)
-
 
 
 vt_session.close()
@@ -2141,7 +2118,12 @@ summarystring += "{:>48s}".format("------------------") + "\n"
 for classification in vt_class:
     summarystring += "{:>40s}  {:10s}".format(classification, str(vt_classifications.count(classification))) + "\n"
 summarystring += "\n"
-summarystring += "{:>60s}".format("Attacks With Uncommon Command Counts", ) + "\n"
+summarystring += (
+    "{:>60s}".format(
+        "Attacks With Uncommon Command Counts",
+    )
+    + "\n"
+)
 summarystring += "{:>60s}".format("------------------------------------") + "\n"
 for each_submission in uncommon_command_counts:
     summarystring += "{:>40s}  {:10s}".format("", each_submission) + "\n"
@@ -2158,22 +2140,22 @@ for each_attack in abnormal_attacks:
     summarystring += "{:>40s}  {:10s}".format("", each_attack) + "\n"
 summarystring += "\n\n"
 
-if (summarizedays):
-    report_file = open(date + "_" + summarizedays + "_day_report.txt","a")
+if summarizedays:
+    report_file = open(date + "_" + summarizedays + "_day_report.txt", "a")
 else:
-    report_file = open(date + "_report.txt","a")
+    report_file = open(date + "_report.txt", "a")
 report_file.write(summarystring)
 report_file.close()
 
-if (summarizedays):
-    report_file = open(date + "_abnormal_" + summarizedays + "-day_report.txt","a")
+if summarizedays:
+    report_file = open(date + "_abnormal_" + summarizedays + "-day_report.txt", "a")
 else:
-    report_file = open(date + "_abnormal_report.txt","a")
+    report_file = open(date + "_abnormal_report.txt", "a")
 report_file.write(summarystring)
 report_file.close()
 print_session_info(data, abnormal_attacks, "abnormal")
 
-if (dbxapi):
+if dbxapi:
     dbx = dropbox.Dropbox(dbxapi)
     with open(date + "_" + summarizedays + "_day_report.txt", 'rb') as f:
         dbx.files_upload(f.read(), "/" + date + filename_prepend + "_" + summarizedays + "_day_report.txt")
@@ -2184,12 +2166,8 @@ if (dbxapi):
     with open("../cowrieprocessor.sqlite", 'rb') as f:
         dbx.files_upload(f.read(), "/" + date + filename_prepend + "_cowrieprocessor.sqlite")
 
-elif (dbxkey and dbxsecret and dbxrefreshtoken):
-    dbx = dropbox.Dropbox(
-            app_key = dbxkey,
-            app_secret = dbxsecret,
-            oauth2_refresh_token = dbxrefreshtoken
-        )
+elif dbxkey and dbxsecret and dbxrefreshtoken:
+    dbx = dropbox.Dropbox(app_key=dbxkey, app_secret=dbxsecret, oauth2_refresh_token=dbxrefreshtoken)
     with open(date + "_" + summarizedays + "_day_report.txt", 'rb') as f:
         dbx.files_upload(f.read(), "/" + date + filename_prepend + "_" + summarizedays + "_day_report.txt")
 
@@ -2202,7 +2180,7 @@ elif (dbxkey and dbxsecret and dbxrefreshtoken):
     except Exception:
         logging.error("Failed to upload DB file to Dropbox", exc_info=True)
 
-else: 
+else:
     print("No Dropbox account information supplied to allow upload")
 
 print(summarystring)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cowrieprocessor"
 version = "0.1.0"
 description = "Process Cowrie honeypot logs with enrichments (VT, DShield, URLHaus, SPUR, Dropbox)."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "BSD-4-Clause"
 keywords = ["cowrie", "honeypot", "security", "virustotal", "dshield", "urlhaus", "spur", "dropbox"]
 dependencies = [
@@ -21,9 +21,10 @@ build-backend = "setuptools.build_meta"
 [tool.uv]
 # Using uv to manage a virtual environment and resolve dependencies from this pyproject.
 dev-dependencies = [
-  "ruff>=0.6.0",
-  "mypy>=1.11.0",
-  "types-requests>=2.32.0.20240914",
+  "ruff==0.12.11",
+  "mypy==1.14.1",
+  "types-requests==2.32.0.20240914",
+  "pre-commit==3.8.0",
 ]
 
 [tool.ruff]

--- a/secrets_resolver.py
+++ b/secrets_resolver.py
@@ -1,0 +1,178 @@
+"""Secret reference resolver for multiple secret managers and sources.
+
+Supports resolving secrets from:
+- env:NAME or ${NAME}
+- file:/path/to/secret
+- op://<vault>/<item>/<field> via 1Password CLI (`op read`)
+- aws-sm://[region/]secret_id[#json_key] via AWS CLI
+- vault://path[#field] via HashiCorp Vault CLI
+- sops://path[#json.key] via SOPS CLI (expects JSON; YAML not supported)
+
+Notes:
+- This module shells out to CLIs if present. It does not manage login flows.
+- It avoids logging or printing secret values. Errors are concise.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+_ENV_PATTERN = re.compile(r"^\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)\}$")
+
+
+def _sh(cmd: list[str], env: Optional[dict] = None) -> str:
+    """Run a command and return stdout as text (stripped)."""
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if result.returncode != 0:
+        # Don't include stdout/stderr as it may contain sensitive info
+        head = " ".join(shlex.quote(c) for c in cmd[:2])
+        raise RuntimeError(f"Command failed: {head} ... (exit {result.returncode})")
+    return result.stdout.strip()
+
+
+def is_reference(value: str | None) -> bool:
+    """Return True if the string looks like a secret reference.
+
+    Supports env/file/op/aws-sm/vault/sops schemes or ${ENV} syntax.
+    """
+    if not value:
+        return False
+    return value.startswith(("env:", "file:", "op://", "aws-sm://", "vault://", "sops://")) or bool(
+        _ENV_PATTERN.match(value)
+    )
+
+
+def resolve_secret(value: Optional[str]) -> Optional[str]:
+    """Resolve a secret value or reference.
+
+    Returns the original value when it is not a supported reference.
+    Returns None when input is None or empty string.
+    Raises RuntimeError on explicit reference failures.
+    """
+    if value is None:
+        return None
+    value = str(value)
+    if value == "":
+        return None
+
+    # ${ENV} syntax
+    m = _ENV_PATTERN.match(value)
+    if m:
+        return os.getenv(m.group("name"))
+
+    # env:NAME
+    if value.startswith("env:"):
+        name = value.split(":", 1)[1]
+        return os.getenv(name)
+
+    # file:/path or file:relative
+    if value.startswith("file:"):
+        path = value.split(":", 1)[1]
+        p = Path(path)
+        data = p.read_text(encoding="utf-8")
+        return data.rstrip("\n")
+
+    # 1Password: op://vault/item/field
+    if value.startswith("op://"):
+        # Use op read which supports secret references directly
+        return _sh(["op", "read", value])
+
+    # AWS Secrets Manager: aws-sm://[region/]secret_id[#json_key]
+    if value.startswith("aws-sm://"):
+        body = value[len("aws-sm://") :]
+        region = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+        if "/" in body and not body.startswith("/"):
+            # Potentially region/secret_id...
+            maybe_region, rest = body.split("/", 1)
+            if maybe_region and "." in maybe_region or maybe_region.count("-") >= 2:
+                region = maybe_region
+                body = rest
+        secret_id, _, key = body.partition("#")
+        if not secret_id:
+            raise RuntimeError("aws-sm reference missing secret_id")
+        cmd = [
+            "aws",
+            "secretsmanager",
+            "get-secret-value",
+            "--secret-id",
+            secret_id,
+            "--query",
+            "SecretString",
+            "--output",
+            "text",
+        ]
+        if region:
+            cmd += ["--region", region]
+        secret = _sh(cmd)
+        if key:
+            try:
+                obj = json.loads(secret)
+            except json.JSONDecodeError as e:
+                raise RuntimeError(f"aws-sm secret is not JSON (needed for key '{key}')") from e
+            if key not in obj:
+                raise RuntimeError(f"aws-sm key '{key}' not found in secret")
+            return str(obj[key])
+        return secret
+
+    # HashiCorp Vault: vault://path[#field] (KV v2 preferred)
+    if value.startswith("vault://"):
+        spec = value[len("vault://") :]
+        path, _, field = spec.partition("#")
+        if field:
+            # vault kv get -field=FIELD path
+            return _sh(["vault", "kv", "get", f"-field={field}", path])
+        else:
+            # Try to fetch JSON and best-effort pick data.data or data
+            raw = _sh(["vault", "kv", "get", "-format=json", path])
+            try:
+                obj = json.loads(raw)
+                data = obj.get("data", {})
+                # KV v2 nests under data.data
+                if isinstance(data, dict) and "data" in data and isinstance(data["data"], dict):
+                    return json.dumps(data["data"])  # Caller can parse
+                return json.dumps(data)
+            except Exception:
+                return raw
+
+    # SOPS: sops://path[#json.key]
+    if value.startswith("sops://"):
+        spec = value[len("sops://") :]
+        path, _, pointer = spec.partition("#")
+        dec = _sh(["sops", "-d", "-o", "/dev/stdout", path])
+        if not pointer:
+            return dec
+        try:
+            obj = json.loads(dec)
+        except json.JSONDecodeError as e:
+            raise RuntimeError("sops decrypted data is not JSON; use a JSON file or omit #key") from e
+        # Support dot.notation path
+        cur = obj
+        for part in pointer.split("."):
+            if not part:
+                continue
+            if not isinstance(cur, dict) or part not in cur:
+                raise RuntimeError(f"sops key '{pointer}' not found")
+            cur = cur[part]
+        return cur if isinstance(cur, str) else json.dumps(cur)
+
+    # Not a reference; return as-is
+    return value
+
+
+def set_env_if_ref(env: dict, var: str, value: Optional[str]) -> Optional[str]:
+    """If `value` is a reference or non-empty literal, resolve and set env[var].
+
+    Returns the resolved secret or None if not set.
+    """
+    if value is None:
+        return None
+    resolved = resolve_secret(value)
+    if resolved is not None:
+        env[var] = str(resolved)
+    return resolved

--- a/sensors.example.toml
+++ b/sensors.example.toml
@@ -9,9 +9,15 @@ summarizedays = 1
 email = "you@example.com"
 # Optional per-sensor override for report_dir
 # report_dir = "/mnt/dshield/reports/honeypot-a"
-# vtapi = "..."
-# urlhausapi = "..."
-# spurapi = "..."
+#
+# Secrets can be provided as plain values or secret references.
+# Recommended: use secret references and let orchestrate_sensors set env vars.
+# Examples:
+# vtapi = "env:VT_API_KEY"                  # from environment
+# vtapi = "op://Security/VirusTotal/api"    # 1Password item field
+# urlhausapi = "aws-sm://us-east-1/urlhaus#api_key"  # AWS Secrets Manager
+# spurapi = "vault://kv/data/spur#token"     # HashiCorp Vault KV v2
+# email = "file:/run/secrets/dshield_email"   # From a file
 
 [[sensor]]
 name = "honeypot-b"

--- a/submit_vtfiles.py
+++ b/submit_vtfiles.py
@@ -13,26 +13,30 @@ import time
 
 import requests
 
+from secrets_resolver import is_reference, resolve_secret
+
 parser = argparse.ArgumentParser(description='Virus Total file submission options')
+parser.add_argument('--filepath', dest='filepath', type=str, help='Path of a specific file to submit')
 parser.add_argument(
-    '--filepath', dest='filepath', type=str,
-    help='Path of a specific file to submit'
-)
-parser.add_argument(
-    '--folderpath', dest='folderpath', type=str,
+    '--folderpath',
+    dest='folderpath',
+    type=str,
     help='Folder ocation of files to process for submission',
-    default='/srv/cowrie/var/lib/cowrie/downloads/'
+    default='/srv/cowrie/var/lib/cowrie/downloads/',
 )
-parser.add_argument(
-    '--vtapi', dest='vtapi', type=str,
-    help='VirusTotal API key (required for VT data lookup)'
-)
+parser.add_argument('--vtapi', dest='vtapi', type=str, help='VirusTotal API key (required for VT data lookup)')
 
 args = parser.parse_args()
 
 filepath = args.filepath
 folderpath = args.folderpath
-vtapi = args.vtapi
+vtapi = args.vtapi or os.getenv('VT_API_KEY')
+try:
+    if is_reference(vtapi):
+        vtapi = resolve_secret(vtapi)
+except Exception:
+    pass
+
 
 def vt_filescan(filename):
     """Submit a file to VirusTotal and record responses.
@@ -57,11 +61,14 @@ def vt_filescan(filename):
     file.close()
 
     filehash = sha256sum(folderpath + filename)
-    headers = {
-        'Content-type': 'application/json',
-        'X-Apikey': vtapi}
+    headers = {'Content-type': 'application/json', 'X-Apikey': vtapi}
     url = "https://www.virustotal.com/api/v3/files/" + filehash + "/comments"
-    commentdata = {'data':{'type': 'comment', 'attributes': {'text': 'File submitted from a DShield Honeypot - https://github.com/DShield-ISC/dshield'}}}
+    commentdata = {
+        'data': {
+            'type': 'comment',
+            'attributes': {'text': 'File submitted from a DShield Honeypot - https://github.com/DShield-ISC/dshield'},
+        }
+    }
     response = requests.post(url, headers=headers, data=json.dumps(commentdata))
     _ = json.loads(response.text)
     file = open("vtsubmissions/files_comment_" + filename, 'w')
@@ -78,15 +85,16 @@ def sha256sum(filename):
     Returns:
         Hex-encoded SHA-256 digest string.
     """
-    h  = hashlib.sha256()
-    b  = bytearray(128*1024)
+    h = hashlib.sha256()
+    b = bytearray(128 * 1024)
     mv = memoryview(b)
     with open(filename, 'rb', buffering=0) as f:
         while n := f.readinto(mv):
             h.update(mv[:n])
     return h.hexdigest()
 
-past = time.time() - ((60*60)/11) #1/11 of an hour - just under 6 minutes
+
+past = time.time() - ((60 * 60) / 11)  # 1/11 of an hour - just under 6 minutes
 result = []
 for p, ds, fs in os.walk(folderpath):
     for fn in fs:
@@ -98,4 +106,4 @@ for each_file in result:
     print(each_file)
     vt_filescan(each_file)
 
-#vt_filescan("58458d88aeb274ebd87a2cc4dad0b64f3c38c8951a287b3b31c1f99c8240d38e")
+# vt_filescan("58458d88aeb274ebd87a2cc4dad0b64f3c38c8951a287b3b31c1f99c8240d38e")

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.8"
-resolution-markers = [
-    "python_full_version >= '3.9'",
-    "python_full_version < '3.9'",
-]
+requires-python = ">=3.9"
 
 [[package]]
 name = "certifi"
@@ -13,6 +9,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
 ]
 
 [[package]]
@@ -76,17 +81,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/72/2a/aff5dd112b2f14bcc3462c312dce5445806bfc8ab3a7328555da95330e4b/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16", size = 152224, upload-time = "2025-08-09T07:56:51.369Z" },
     { url = "https://files.pythonhosted.org/packages/b7/8c/9839225320046ed279c6e839d51f028342eb77c91c89b8ef2549f951f3ec/charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce", size = 100086, upload-time = "2025-08-09T07:56:52.722Z" },
     { url = "https://files.pythonhosted.org/packages/ee/7a/36fbcf646e41f710ce0a563c1c9a343c6edf9be80786edeb15b6f62e17db/charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c", size = 107400, upload-time = "2025-08-09T07:56:55.172Z" },
-    { url = "https://files.pythonhosted.org/packages/22/82/63a45bfc36f73efe46731a3a71cb84e2112f7e0b049507025ce477f0f052/charset_normalizer-3.4.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:0f2be7e0cf7754b9a30eb01f4295cc3d4358a479843b31f328afd210e2c7598c", size = 198805, upload-time = "2025-08-09T07:56:56.496Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/52/8b0c6c3e53f7e546a5e49b9edb876f379725914e1130297f3b423c7b71c5/charset_normalizer-3.4.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c60e092517a73c632ec38e290eba714e9627abe9d301c8c8a12ec32c314a2a4b", size = 142862, upload-time = "2025-08-09T07:56:57.751Z" },
-    { url = "https://files.pythonhosted.org/packages/59/c0/a74f3bd167d311365e7973990243f32c35e7a94e45103125275b9e6c479f/charset_normalizer-3.4.3-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:252098c8c7a873e17dd696ed98bbe91dbacd571da4b87df3736768efa7a792e4", size = 155104, upload-time = "2025-08-09T07:56:58.984Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/79/ae516e678d6e32df2e7e740a7be51dc80b700e2697cb70054a0f1ac2c955/charset_normalizer-3.4.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3653fad4fe3ed447a596ae8638b437f827234f01a8cd801842e43f3d0a6b281b", size = 152598, upload-time = "2025-08-09T07:57:00.201Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bd/ef9c88464b126fa176f4ef4a317ad9b6f4d30b2cffbc43386062367c3e2c/charset_normalizer-3.4.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8999f965f922ae054125286faf9f11bc6932184b93011d138925a1773830bbe9", size = 147391, upload-time = "2025-08-09T07:57:01.441Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/03/cbb6fac9d3e57f7e07ce062712ee80d80a5ab46614684078461917426279/charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d95bfb53c211b57198bb91c46dd5a2d8018b3af446583aab40074bf7988401cb", size = 145037, upload-time = "2025-08-09T07:57:02.638Z" },
-    { url = "https://files.pythonhosted.org/packages/64/d1/f9d141c893ef5d4243bc75c130e95af8fd4bc355beff06e9b1e941daad6e/charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:5b413b0b1bfd94dbf4023ad6945889f374cd24e3f62de58d6bb102c4d9ae534a", size = 156425, upload-time = "2025-08-09T07:57:03.898Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/35/9c99739250742375167bc1b1319cd1cec2bf67438a70d84b2e1ec4c9daa3/charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:b5e3b2d152e74e100a9e9573837aba24aab611d39428ded46f4e4022ea7d1942", size = 153734, upload-time = "2025-08-09T07:57:05.549Z" },
-    { url = "https://files.pythonhosted.org/packages/50/10/c117806094d2c956ba88958dab680574019abc0c02bcf57b32287afca544/charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:a2d08ac246bb48479170408d6c19f6385fa743e7157d716e144cad849b2dd94b", size = 148551, upload-time = "2025-08-09T07:57:06.823Z" },
-    { url = "https://files.pythonhosted.org/packages/61/c5/dc3ba772489c453621ffc27e8978a98fe7e41a93e787e5e5bde797f1dddb/charset_normalizer-3.4.3-cp38-cp38-win32.whl", hash = "sha256:ec557499516fc90fd374bf2e32349a2887a876fbf162c160e3c01b6849eaf557", size = 98459, upload-time = "2025-08-09T07:57:08.031Z" },
-    { url = "https://files.pythonhosted.org/packages/05/35/bb59b1cd012d7196fc81c2f5879113971efc226a63812c9cf7f89fe97c40/charset_normalizer-3.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:5d8d01eac18c423815ed4f4a2ec3b439d654e55ee4ad610e153cf02faf67ea40", size = 105887, upload-time = "2025-08-09T07:57:09.401Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ca/9a0983dd5c8e9733565cf3db4df2b0a2e9a82659fd8aa2a868ac6e4a991f/charset_normalizer-3.4.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:70bfc5f2c318afece2f5838ea5e4c3febada0be750fcf4775641052bbba14d05", size = 207520, upload-time = "2025-08-09T07:57:11.026Z" },
     { url = "https://files.pythonhosted.org/packages/39/c6/99271dc37243a4f925b09090493fb96c9333d7992c6187f5cfe5312008d2/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23b6b24d74478dc833444cbd927c338349d6ae852ba53a0d02a2de1fce45b96e", size = 147307, upload-time = "2025-08-09T07:57:12.4Z" },
     { url = "https://files.pythonhosted.org/packages/e4/69/132eab043356bba06eb333cc2cc60c6340857d0a2e4ca6dc2b51312886b3/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:34a7f768e3f985abdb42841e20e17b330ad3aaf4bb7e7aeeb73db2e70f077b99", size = 160448, upload-time = "2025-08-09T07:57:13.712Z" },
@@ -110,17 +104,15 @@ dependencies = [
     { name = "ipaddress" },
     { name = "pathlib" },
     { name = "python-dateutil" },
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "requests" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "mypy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "mypy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "mypy" },
+    { name = "pre-commit" },
     { name = "ruff" },
-    { name = "types-requests", version = "2.32.0.20241016", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "types-requests", version = "2.32.4.20250913", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -134,9 +126,19 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.11.0" },
-    { name = "ruff", specifier = ">=0.6.0" },
-    { name = "types-requests", specifier = ">=2.32.0.20240914" },
+    { name = "mypy", specifier = "==1.14.1" },
+    { name = "pre-commit", specifier = "==3.8.0" },
+    { name = "ruff", specifier = "==0.12.11" },
+    { name = "types-requests", specifier = "==2.32.0.20240914" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
 ]
 
 [[package]]
@@ -144,14 +146,31 @@ name = "dropbox"
 version = "12.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "requests" },
     { name = "six" },
     { name = "stone" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/56/ac085f58e8e0d0bcafdf98c2605e454ac946e3d0c72679669ae112dc30be/dropbox-12.0.2.tar.gz", hash = "sha256:50057fd5ad5fcf047f542dfc6747a896e7ef982f1b5f8500daf51f3abd609962", size = 560236, upload-time = "2024-06-03T16:45:30.448Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/de/95d8204d9a20fbdb353c5f8e4229b0fcb90f22b96f8246ff1f47c8a45fd5/dropbox-12.0.2-py3-none-any.whl", hash = "sha256:c5b7e9c2668adb6b12dcecd84342565dc50f7d35ab6a748d155cb79040979d1c", size = 572076, upload-time = "2024-06-03T16:45:28.153Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/c4/62963f25a678f6a050fb0505a65e9e726996171e6dbe1547f79619eefb15/identify-2.6.14.tar.gz", hash = "sha256:663494103b4f717cb26921c52f8751363dc89db64364cd836a9bf1535f53cd6a", size = 99283, upload-time = "2025-09-06T19:30:52.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl", hash = "sha256:11a073da82212c6646b1f39bb20d4483bfb9543bd5566fec60053c4bb309bf2e", size = 99172, upload-time = "2025-09-06T19:30:51.759Z" },
 ]
 
 [[package]]
@@ -176,13 +195,10 @@ wheels = [
 name = "mypy"
 version = "1.14.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
 dependencies = [
-    { name = "mypy-extensions", marker = "python_full_version < '3.9'" },
-    { name = "tomli", marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "mypy-extensions" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/eb/2c92d8ea1e684440f54fa49ac5d9a5f19967b7b472a281f419e69a8d228e/mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6", size = 3216051, upload-time = "2024-12-30T16:39:07.335Z" }
 wheels = [
@@ -210,12 +226,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/9d/4a236b9c57f5d8f08ed346914b3f091a62dd7e19336b2b2a0d85485f82ff/mypy-1.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4b19b03fdf54f3c5b2fa474c56b4c13c9dbfb9a2db4370ede7ec11a2c5927d9", size = 12867660, upload-time = "2024-12-30T16:38:17.342Z" },
     { url = "https://files.pythonhosted.org/packages/40/88/a61a5497e2f68d9027de2bb139c7bb9abaeb1be1584649fa9d807f80a338/mypy-1.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0c911fde686394753fff899c409fd4e16e9b294c24bfd5e1ea4675deae1ac6fd", size = 12969198, upload-time = "2024-12-30T16:38:32.839Z" },
     { url = "https://files.pythonhosted.org/packages/54/da/3d6fc5d92d324701b0c23fb413c853892bfe0e1dbe06c9138037d459756b/mypy-1.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:8b21525cb51671219f5307be85f7e646a153e5acc656e5cebf64bfa076c50107", size = 9885276, upload-time = "2024-12-30T16:38:20.828Z" },
-    { url = "https://files.pythonhosted.org/packages/39/02/1817328c1372be57c16148ce7d2bfcfa4a796bedaed897381b1aad9b267c/mypy-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7084fb8f1128c76cd9cf68fe5971b37072598e7c31b2f9f95586b65c741a9d31", size = 11143050, upload-time = "2024-12-30T16:38:29.743Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/07/99db9a95ece5e58eee1dd87ca456a7e7b5ced6798fd78182c59c35a7587b/mypy-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8f845a00b4f420f693f870eaee5f3e2692fa84cc8514496114649cfa8fd5e2c6", size = 10321087, upload-time = "2024-12-30T16:38:14.739Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/eb/85ea6086227b84bce79b3baf7f465b4732e0785830726ce4a51528173b71/mypy-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44bf464499f0e3a2d14d58b54674dee25c031703b2ffc35064bd0df2e0fac319", size = 12066766, upload-time = "2024-12-30T16:38:47.038Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/bb/f01bebf76811475d66359c259eabe40766d2f8ac8b8250d4e224bb6df379/mypy-1.14.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99f27732c0b7dc847adb21c9d47ce57eb48fa33a17bc6d7d5c5e9f9e7ae5bac", size = 12787111, upload-time = "2024-12-30T16:39:02.444Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/c9/84837ff891edcb6dcc3c27d85ea52aab0c4a34740ff5f0ccc0eb87c56139/mypy-1.14.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:bce23c7377b43602baa0bd22ea3265c49b9ff0b76eb315d6c34721af4cdf1d9b", size = 12974331, upload-time = "2024-12-30T16:38:23.849Z" },
-    { url = "https://files.pythonhosted.org/packages/84/5f/901e18464e6a13f8949b4909535be3fa7f823291b8ab4e4b36cfe57d6769/mypy-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:8edc07eeade7ebc771ff9cf6b211b9a7d93687ff892150cb5692e4f4272b0837", size = 9763210, upload-time = "2024-12-30T16:38:36.299Z" },
     { url = "https://files.pythonhosted.org/packages/ca/1f/186d133ae2514633f8558e78cd658070ba686c0e9275c5a5c24a1e1f0d67/mypy-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3888a1816d69f7ab92092f785a462944b3ca16d7c470d564165fe703b0970c35", size = 11200493, upload-time = "2024-12-30T16:38:26.935Z" },
     { url = "https://files.pythonhosted.org/packages/af/fc/4842485d034e38a4646cccd1369f6b1ccd7bc86989c52770d75d719a9941/mypy-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46c756a444117c43ee984bd055db99e498bc613a70bbbc120272bd13ca579fbc", size = 10357702, upload-time = "2024-12-30T16:38:50.623Z" },
     { url = "https://files.pythonhosted.org/packages/b4/e6/457b83f2d701e23869cfec013a48a12638f75b9d37612a9ddf99072c1051/mypy-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27fc248022907e72abfd8e22ab1f10e903915ff69961174784a3900a8cba9ad9", size = 12091104, upload-time = "2024-12-30T16:38:53.735Z" },
@@ -223,60 +233,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/bc/0bc6b694b3103de9fed61867f1c8bd33336b913d16831431e7cb48ef1c92/mypy-1.14.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:57961db9795eb566dc1d1b4e9139ebc4c6b0cb6e7254ecde69d1552bf7613f60", size = 13013834, upload-time = "2024-12-30T16:38:59.204Z" },
     { url = "https://files.pythonhosted.org/packages/b0/79/5f5ec47849b6df1e6943d5fd8e6632fbfc04b4fd4acfa5a5a9535d11b4e2/mypy-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:07ba89fdcc9451f2ebb02853deb6aaaa3d2239a236669a63ab3801bbf923ef5c", size = 9781231, upload-time = "2024-12-30T16:39:05.124Z" },
     { url = "https://files.pythonhosted.org/packages/a0/b5/32dd67b69a16d088e533962e5044e51004176a9952419de0370cdaead0f8/mypy-1.14.1-py3-none-any.whl", hash = "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1", size = 2752905, upload-time = "2024-12-30T16:38:42.021Z" },
-]
-
-[[package]]
-name = "mypy"
-version = "1.18.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.9'",
-]
-dependencies = [
-    { name = "mypy-extensions", marker = "python_full_version >= '3.9'" },
-    { name = "pathspec", marker = "python_full_version >= '3.9'" },
-    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/14/a3/931e09fc02d7ba96da65266884da4e4a8806adcdb8a57faaacc6edf1d538/mypy-1.18.1.tar.gz", hash = "sha256:9e988c64ad3ac5987f43f5154f884747faf62141b7f842e87465b45299eea5a9", size = 3448447, upload-time = "2025-09-11T23:00:47.067Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/06/29ea5a34c23938ae93bc0040eb2900eb3f0f2ef4448cc59af37ab3ddae73/mypy-1.18.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2761b6ae22a2b7d8e8607fb9b81ae90bc2e95ec033fd18fa35e807af6c657763", size = 12811535, upload-time = "2025-09-11T22:58:55.399Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/40/04c38cb04fa9f1dc224b3e9634021a92c47b1569f1c87dfe6e63168883bb/mypy-1.18.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5b10e3ea7f2eec23b4929a3fabf84505da21034a4f4b9613cda81217e92b74f3", size = 11897559, upload-time = "2025-09-11T22:59:48.041Z" },
-    { url = "https://files.pythonhosted.org/packages/46/bf/4c535bd45ea86cebbc1a3b6a781d442f53a4883f322ebd2d442db6444d0b/mypy-1.18.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:261fbfced030228bc0f724d5d92f9ae69f46373bdfd0e04a533852677a11dbea", size = 12507430, upload-time = "2025-09-11T22:59:30.415Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/e1/cbefb16f2be078d09e28e0b9844e981afb41f6ffc85beb68b86c6976e641/mypy-1.18.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4dc6b34a1c6875e6286e27d836a35c0d04e8316beac4482d42cfea7ed2527df8", size = 13243717, upload-time = "2025-09-11T22:59:11.297Z" },
-    { url = "https://files.pythonhosted.org/packages/65/e8/3e963da63176f16ca9caea7fa48f1bc8766de317cd961528c0391565fd47/mypy-1.18.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1cabb353194d2942522546501c0ff75c4043bf3b63069cb43274491b44b773c9", size = 13492052, upload-time = "2025-09-11T23:00:09.29Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/09/d5d70c252a3b5b7530662d145437bd1de15f39fa0b48a27ee4e57d254aa1/mypy-1.18.1-cp310-cp310-win_amd64.whl", hash = "sha256:738b171690c8e47c93569635ee8ec633d2cdb06062f510b853b5f233020569a9", size = 9765846, upload-time = "2025-09-11T22:58:26.198Z" },
-    { url = "https://files.pythonhosted.org/packages/32/28/47709d5d9e7068b26c0d5189c8137c8783e81065ad1102b505214a08b548/mypy-1.18.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6c903857b3e28fc5489e54042684a9509039ea0aedb2a619469438b544ae1961", size = 12734635, upload-time = "2025-09-11T23:00:24.983Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/12/ee5c243e52497d0e59316854041cf3b3130131b92266d0764aca4dec3c00/mypy-1.18.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2a0c8392c19934c2b6c65566d3a6abdc6b51d5da7f5d04e43f0eb627d6eeee65", size = 11817287, upload-time = "2025-09-11T22:59:07.38Z" },
-    { url = "https://files.pythonhosted.org/packages/48/bd/2aeb950151005fe708ab59725afed7c4aeeb96daf844f86a05d4b8ac34f8/mypy-1.18.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f85eb7efa2ec73ef63fc23b8af89c2fe5bf2a4ad985ed2d3ff28c1bb3c317c92", size = 12430464, upload-time = "2025-09-11T22:58:48.084Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e8/7a20407aafb488acb5734ad7fb5e8c2ef78d292ca2674335350fa8ebef67/mypy-1.18.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:82ace21edf7ba8af31c3308a61dc72df30500f4dbb26f99ac36b4b80809d7e94", size = 13164555, upload-time = "2025-09-11T23:00:13.803Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/c9/5f39065252e033b60f397096f538fb57c1d9fd70a7a490f314df20dd9d64/mypy-1.18.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a2dfd53dfe632f1ef5d161150a4b1f2d0786746ae02950eb3ac108964ee2975a", size = 13359222, upload-time = "2025-09-11T23:00:33.469Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b6/d54111ef3c1e55992cd2ec9b8b6ce9c72a407423e93132cae209f7e7ba60/mypy-1.18.1-cp311-cp311-win_amd64.whl", hash = "sha256:320f0ad4205eefcb0e1a72428dde0ad10be73da9f92e793c36228e8ebf7298c0", size = 9760441, upload-time = "2025-09-11T23:00:44.826Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/14/1c3f54d606cb88a55d1567153ef3a8bc7b74702f2ff5eb64d0994f9e49cb/mypy-1.18.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:502cde8896be8e638588b90fdcb4c5d5b8c1b004dfc63fd5604a973547367bb9", size = 12911082, upload-time = "2025-09-11T23:00:41.465Z" },
-    { url = "https://files.pythonhosted.org/packages/90/83/235606c8b6d50a8eba99773add907ce1d41c068edb523f81eb0d01603a83/mypy-1.18.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7509549b5e41be279afc1228242d0e397f1af2919a8f2877ad542b199dc4083e", size = 11919107, upload-time = "2025-09-11T22:58:40.903Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/25/4e2ce00f8d15b99d0c68a2536ad63e9eac033f723439ef80290ec32c1ff5/mypy-1.18.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5956ecaabb3a245e3f34100172abca1507be687377fe20e24d6a7557e07080e2", size = 12472551, upload-time = "2025-09-11T22:58:37.272Z" },
-    { url = "https://files.pythonhosted.org/packages/32/bb/92642a9350fc339dd9dcefcf6862d171b52294af107d521dce075f32f298/mypy-1.18.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8750ceb014a96c9890421c83f0db53b0f3b8633e2864c6f9bc0a8e93951ed18d", size = 13340554, upload-time = "2025-09-11T22:59:38.756Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ee/38d01db91c198fb6350025d28f9719ecf3c8f2c55a0094bfbf3ef478cc9a/mypy-1.18.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fb89ea08ff41adf59476b235293679a6eb53a7b9400f6256272fb6029bec3ce5", size = 13530933, upload-time = "2025-09-11T22:59:20.228Z" },
-    { url = "https://files.pythonhosted.org/packages/da/8d/6d991ae631f80d58edbf9d7066e3f2a96e479dca955d9a968cd6e90850a3/mypy-1.18.1-cp312-cp312-win_amd64.whl", hash = "sha256:2657654d82fcd2a87e02a33e0d23001789a554059bbf34702d623dafe353eabf", size = 9828426, upload-time = "2025-09-11T23:00:21.007Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/ec/ef4a7260e1460a3071628a9277a7579e7da1b071bc134ebe909323f2fbc7/mypy-1.18.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d70d2b5baf9b9a20bc9c730015615ae3243ef47fb4a58ad7b31c3e0a59b5ef1f", size = 12918671, upload-time = "2025-09-11T22:58:29.814Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/82/0ea6c3953f16223f0b8eda40c1aeac6bd266d15f4902556ae6e91f6fca4c/mypy-1.18.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b8367e33506300f07a43012fc546402f283c3f8bcff1dc338636affb710154ce", size = 11913023, upload-time = "2025-09-11T23:00:29.049Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/ef/5e2057e692c2690fc27b3ed0a4dbde4388330c32e2576a23f0302bc8358d/mypy-1.18.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:913f668ec50c3337b89df22f973c1c8f0b29ee9e290a8b7fe01cc1ef7446d42e", size = 12473355, upload-time = "2025-09-11T23:00:04.544Z" },
-    { url = "https://files.pythonhosted.org/packages/98/43/b7e429fc4be10e390a167b0cd1810d41cb4e4add4ae50bab96faff695a3b/mypy-1.18.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a0e70b87eb27b33209fa4792b051c6947976f6ab829daa83819df5f58330c71", size = 13346944, upload-time = "2025-09-11T22:58:23.024Z" },
-    { url = "https://files.pythonhosted.org/packages/89/4e/899dba0bfe36bbd5b7c52e597de4cf47b5053d337b6d201a30e3798e77a6/mypy-1.18.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c378d946e8a60be6b6ede48c878d145546fb42aad61df998c056ec151bf6c746", size = 13512574, upload-time = "2025-09-11T22:59:52.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/f8/7661021a5b0e501b76440454d786b0f01bb05d5c4b125fcbda02023d0250/mypy-1.18.1-cp313-cp313-win_amd64.whl", hash = "sha256:2cd2c1e0f3a7465f22731987fff6fc427e3dcbb4ca5f7db5bbeaff2ff9a31f6d", size = 9837684, upload-time = "2025-09-11T22:58:44.454Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/87/7b173981466219eccc64c107cf8e5ab9eb39cc304b4c07df8e7881533e4f/mypy-1.18.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ba24603c58e34dd5b096dfad792d87b304fc6470cbb1c22fd64e7ebd17edcc61", size = 12900265, upload-time = "2025-09-11T22:59:03.4Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/cc/b10e65bae75b18a5ac8f81b1e8e5867677e418f0dd2c83b8e2de9ba96ebd/mypy-1.18.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ed36662fb92ae4cb3cacc682ec6656208f323bbc23d4b08d091eecfc0863d4b5", size = 11942890, upload-time = "2025-09-11T23:00:00.607Z" },
-    { url = "https://files.pythonhosted.org/packages/39/d4/aeefa07c44d09f4c2102e525e2031bc066d12e5351f66b8a83719671004d/mypy-1.18.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:040ecc95e026f71a9ad7956fea2724466602b561e6a25c2e5584160d3833aaa8", size = 12472291, upload-time = "2025-09-11T22:59:43.425Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/07/711e78668ff8e365f8c19735594ea95938bff3639a4c46a905e3ed8ff2d6/mypy-1.18.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:937e3ed86cb731276706e46e03512547e43c391a13f363e08d0fee49a7c38a0d", size = 13318610, upload-time = "2025-09-11T23:00:17.604Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/85/df3b2d39339c31d360ce299b418c55e8194ef3205284739b64962f6074e7/mypy-1.18.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1f95cc4f01c0f1701ca3b0355792bccec13ecb2ec1c469e5b85a6ef398398b1d", size = 13513697, upload-time = "2025-09-11T22:58:59.534Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/df/462866163c99ea73bb28f0eb4d415c087e30de5d36ee0f5429d42e28689b/mypy-1.18.1-cp314-cp314-win_amd64.whl", hash = "sha256:e4f16c0019d48941220ac60b893615be2f63afedaba6a0801bdcd041b96991ce", size = 9985739, upload-time = "2025-09-11T22:58:51.644Z" },
-    { url = "https://files.pythonhosted.org/packages/64/1a/9005d78ffedaac58b3ee3a44d53a65b09ac1d27c36a00ade849015b8e014/mypy-1.18.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e37763af63a8018308859bc83d9063c501a5820ec5bd4a19f0a2ac0d1c25c061", size = 12809347, upload-time = "2025-09-11T22:59:15.468Z" },
-    { url = "https://files.pythonhosted.org/packages/46/b3/c932216b281f7c223a2c8b98b9c8e1eb5bea1650c11317ac778cfc3778e4/mypy-1.18.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:51531b6e94f34b8bd8b01dee52bbcee80daeac45e69ec5c36e25bce51cbc46e6", size = 11899906, upload-time = "2025-09-11T22:59:56.473Z" },
-    { url = "https://files.pythonhosted.org/packages/30/6b/542daf553f97275677c35d183404d1d83b64cea315f452195c5a5782a225/mypy-1.18.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbfdea20e90e9c5476cea80cfd264d8e197c6ef2c58483931db2eefb2f7adc14", size = 12504415, upload-time = "2025-09-11T23:00:37.332Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d3/061d0d861377ea3fdb03784d11260bfa2adbb4eeeb24b63bd1eea7b6080c/mypy-1.18.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99f272c9b59f5826fffa439575716276d19cbf9654abc84a2ba2d77090a0ba14", size = 13243466, upload-time = "2025-09-11T22:58:18.562Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/5e/6e88a79bdfec8d01ba374c391150c94f6c74545bdc37bdc490a7f30c5095/mypy-1.18.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8c05a7f8c00300a52f3a4fcc95a185e99bf944d7e851ff141bae8dcf6dcfeac4", size = 13493539, upload-time = "2025-09-11T22:59:24.479Z" },
-    { url = "https://files.pythonhosted.org/packages/92/5a/a14a82e44ed76998d73a070723b6584963fdb62f597d373c8b22c3a3da3d/mypy-1.18.1-cp39-cp39-win_amd64.whl", hash = "sha256:2fbcecbe5cf213ba294aa8c0b8c104400bf7bb64db82fb34fe32a205da4b3531", size = 9764809, upload-time = "2025-09-11T22:58:33.133Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/1d/4b97d3089b48ef3d904c9ca69fab044475bd03245d878f5f0b3ea1daf7ce/mypy-1.18.1-py3-none-any.whl", hash = "sha256:b76a4de66a0ac01da1be14ecc8ae88ddea33b8380284a9e3eae39d57ebcbe26e", size = 2352212, upload-time = "2025-09-11T22:59:26.576Z" },
 ]
 
 [[package]]
@@ -289,6 +245,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
 name = "pathlib"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -298,12 +263,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
+name = "platformdirs"
+version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
 ]
 
 [[package]]
@@ -313,6 +278,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/10/97ee2fa54dff1e9da9badbc5e35d0bbaef0776271ea5907eccf64140f72f/pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af", size = 177815, upload-time = "2024-07-28T19:59:01.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/92/caae8c86e94681b42c246f0bca35c059a2f0529e5b92619f6aba4cf7e7b6/pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f", size = 204643, upload-time = "2024-07-28T19:58:59.335Z" },
 ]
 
 [[package]]
@@ -328,35 +309,67 @@ wheels = [
 ]
 
 [[package]]
-name = "requests"
-version = "2.32.4"
+name = "pyyaml"
+version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.9'" },
-    { name = "charset-normalizer", marker = "python_full_version < '3.9'" },
-    { name = "idna", marker = "python_full_version < '3.9'" },
-    { name = "urllib3", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199, upload-time = "2024-08-06T20:31:40.178Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758, upload-time = "2024-08-06T20:31:42.173Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463, upload-time = "2024-08-06T20:31:44.263Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280, upload-time = "2024-08-06T20:31:50.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239, upload-time = "2024-08-06T20:31:52.292Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802, upload-time = "2024-08-06T20:31:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527, upload-time = "2024-08-06T20:31:55.565Z" },
+    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052, upload-time = "2024-08-06T20:31:56.914Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774, upload-time = "2024-08-06T20:31:58.304Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167, upload-time = "2024-08-06T20:32:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952, upload-time = "2024-08-06T20:32:14.124Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301, upload-time = "2024-08-06T20:32:16.17Z" },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638, upload-time = "2024-08-06T20:32:18.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850, upload-time = "2024-08-06T20:32:19.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980, upload-time = "2024-08-06T20:32:21.273Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777, upload-time = "2024-08-06T20:33:25.896Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318, upload-time = "2024-08-06T20:33:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891, upload-time = "2024-08-06T20:33:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614, upload-time = "2024-08-06T20:33:34.157Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360, upload-time = "2024-08-06T20:33:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006, upload-time = "2024-08-06T20:33:37.501Z" },
+    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577, upload-time = "2024-08-06T20:33:39.389Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593, upload-time = "2024-08-06T20:33:46.63Z" },
+    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312, upload-time = "2024-08-06T20:33:49.073Z" },
 ]
 
 [[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.9'",
-]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.9'" },
-    { name = "charset-normalizer", marker = "python_full_version >= '3.9'" },
-    { name = "idna", marker = "python_full_version >= '3.9'" },
-    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
@@ -365,28 +378,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.13.0"
+version = "0.12.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6e/1a/1f4b722862840295bcaba8c9e5261572347509548faaa99b2d57ee7bfe6a/ruff-0.13.0.tar.gz", hash = "sha256:5b4b1ee7eb35afae128ab94459b13b2baaed282b1fb0f472a73c82c996c8ae60", size = 5372863, upload-time = "2025-09-10T16:25:37.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/55/16ab6a7d88d93001e1ae4c34cbdcfb376652d761799459ff27c1dc20f6fa/ruff-0.12.11.tar.gz", hash = "sha256:c6b09ae8426a65bbee5425b9d0b82796dbb07cb1af045743c79bfb163001165d", size = 5347103, upload-time = "2025-08-28T13:59:08.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/fe/6f87b419dbe166fd30a991390221f14c5b68946f389ea07913e1719741e0/ruff-0.13.0-py3-none-linux_armv6l.whl", hash = "sha256:137f3d65d58ee828ae136a12d1dc33d992773d8f7644bc6b82714570f31b2004", size = 12187826, upload-time = "2025-09-10T16:24:39.5Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/25/c92296b1fc36d2499e12b74a3fdb230f77af7bdf048fad7b0a62e94ed56a/ruff-0.13.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:21ae48151b66e71fd111b7d79f9ad358814ed58c339631450c66a4be33cc28b9", size = 12933428, upload-time = "2025-09-10T16:24:43.866Z" },
-    { url = "https://files.pythonhosted.org/packages/44/cf/40bc7221a949470307d9c35b4ef5810c294e6cfa3caafb57d882731a9f42/ruff-0.13.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:64de45f4ca5441209e41742d527944635a05a6e7c05798904f39c85bafa819e3", size = 12095543, upload-time = "2025-09-10T16:24:46.638Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/03/8b5ff2a211efb68c63a1d03d157e924997ada87d01bebffbd13a0f3fcdeb/ruff-0.13.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b2c653ae9b9d46e0ef62fc6fbf5b979bda20a0b1d2b22f8f7eb0cde9f4963b8", size = 12312489, upload-time = "2025-09-10T16:24:49.556Z" },
-    { url = "https://files.pythonhosted.org/packages/37/fc/2336ef6d5e9c8d8ea8305c5f91e767d795cd4fc171a6d97ef38a5302dadc/ruff-0.13.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4cec632534332062bc9eb5884a267b689085a1afea9801bf94e3ba7498a2d207", size = 11991631, upload-time = "2025-09-10T16:24:53.439Z" },
-    { url = "https://files.pythonhosted.org/packages/39/7f/f6d574d100fca83d32637d7f5541bea2f5e473c40020bbc7fc4a4d5b7294/ruff-0.13.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dcd628101d9f7d122e120ac7c17e0a0f468b19bc925501dbe03c1cb7f5415b24", size = 13720602, upload-time = "2025-09-10T16:24:56.392Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/c8/a8a5b81d8729b5d1f663348d11e2a9d65a7a9bd3c399763b1a51c72be1ce/ruff-0.13.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:afe37db8e1466acb173bb2a39ca92df00570e0fd7c94c72d87b51b21bb63efea", size = 14697751, upload-time = "2025-09-10T16:24:59.89Z" },
-    { url = "https://files.pythonhosted.org/packages/57/f5/183ec292272ce7ec5e882aea74937f7288e88ecb500198b832c24debc6d3/ruff-0.13.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f96a8d90bb258d7d3358b372905fe7333aaacf6c39e2408b9f8ba181f4b6ef2", size = 14095317, upload-time = "2025-09-10T16:25:03.025Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/8d/7f9771c971724701af7926c14dab31754e7b303d127b0d3f01116faef456/ruff-0.13.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94b5e3d883e4f924c5298e3f2ee0f3085819c14f68d1e5b6715597681433f153", size = 13144418, upload-time = "2025-09-10T16:25:06.272Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/a6/7985ad1778e60922d4bef546688cd8a25822c58873e9ff30189cfe5dc4ab/ruff-0.13.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03447f3d18479df3d24917a92d768a89f873a7181a064858ea90a804a7538991", size = 13370843, upload-time = "2025-09-10T16:25:09.965Z" },
-    { url = "https://files.pythonhosted.org/packages/64/1c/bafdd5a7a05a50cc51d9f5711da704942d8dd62df3d8c70c311e98ce9f8a/ruff-0.13.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fbc6b1934eb1c0033da427c805e27d164bb713f8e273a024a7e86176d7f462cf", size = 13321891, upload-time = "2025-09-10T16:25:12.969Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/3e/7817f989cb9725ef7e8d2cee74186bf90555279e119de50c750c4b7a72fe/ruff-0.13.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a8ab6a3e03665d39d4a25ee199d207a488724f022db0e1fe4002968abdb8001b", size = 12119119, upload-time = "2025-09-10T16:25:16.621Z" },
-    { url = "https://files.pythonhosted.org/packages/58/07/9df080742e8d1080e60c426dce6e96a8faf9a371e2ce22eef662e3839c95/ruff-0.13.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d2a5c62f8ccc6dd2fe259917482de7275cecc86141ee10432727c4816235bc41", size = 11961594, upload-time = "2025-09-10T16:25:19.49Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/f4/ae1185349197d26a2316840cb4d6c3fba61d4ac36ed728bf0228b222d71f/ruff-0.13.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b7b85ca27aeeb1ab421bc787009831cffe6048faae08ad80867edab9f2760945", size = 12933377, upload-time = "2025-09-10T16:25:22.371Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/39/e776c10a3b349fc8209a905bfb327831d7516f6058339a613a8d2aaecacd/ruff-0.13.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:79ea0c44a3032af768cabfd9616e44c24303af49d633b43e3a5096e009ebe823", size = 13418555, upload-time = "2025-09-10T16:25:25.681Z" },
-    { url = "https://files.pythonhosted.org/packages/46/09/dca8df3d48e8b3f4202bf20b1658898e74b6442ac835bfe2c1816d926697/ruff-0.13.0-py3-none-win32.whl", hash = "sha256:4e473e8f0e6a04e4113f2e1de12a5039579892329ecc49958424e5568ef4f768", size = 12141613, upload-time = "2025-09-10T16:25:28.664Z" },
-    { url = "https://files.pythonhosted.org/packages/61/21/0647eb71ed99b888ad50e44d8ec65d7148babc0e242d531a499a0bbcda5f/ruff-0.13.0-py3-none-win_amd64.whl", hash = "sha256:48e5c25c7a3713eea9ce755995767f4dcd1b0b9599b638b12946e892123d1efb", size = 13258250, upload-time = "2025-09-10T16:25:31.773Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/a3/03216a6a86c706df54422612981fb0f9041dbb452c3401501d4a22b942c9/ruff-0.13.0-py3-none-win_arm64.whl", hash = "sha256:ab80525317b1e1d38614addec8ac954f1b3e662de9d59114ecbf771d00cf613e", size = 12312357, upload-time = "2025-09-10T16:25:35.595Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a2/3b3573e474de39a7a475f3fbaf36a25600bfeb238e1a90392799163b64a0/ruff-0.12.11-py3-none-linux_armv6l.whl", hash = "sha256:93fce71e1cac3a8bf9200e63a38ac5c078f3b6baebffb74ba5274fb2ab276065", size = 11979885, upload-time = "2025-08-28T13:58:26.654Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e4/235ad6d1785a2012d3ded2350fd9bc5c5af8c6f56820e696b0118dfe7d24/ruff-0.12.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b8e33ac7b28c772440afa80cebb972ffd823621ded90404f29e5ab6d1e2d4b93", size = 12742364, upload-time = "2025-08-28T13:58:30.256Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0d/15b72c5fe6b1e402a543aa9d8960e0a7e19dfb079f5b0b424db48b7febab/ruff-0.12.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d69fb9d4937aa19adb2e9f058bc4fbfe986c2040acb1a4a9747734834eaa0bfd", size = 11920111, upload-time = "2025-08-28T13:58:33.677Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/f66339d7893798ad3e17fa5a1e587d6fd9806f7c1c062b63f8b09dda6702/ruff-0.12.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:411954eca8464595077a93e580e2918d0a01a19317af0a72132283e28ae21bee", size = 12160060, upload-time = "2025-08-28T13:58:35.74Z" },
+    { url = "https://files.pythonhosted.org/packages/03/69/9870368326db26f20c946205fb2d0008988aea552dbaec35fbacbb46efaa/ruff-0.12.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6a2c0a2e1a450f387bf2c6237c727dd22191ae8c00e448e0672d624b2bbd7fb0", size = 11799848, upload-time = "2025-08-28T13:58:38.051Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8c/dd2c7f990e9b3a8a55eee09d4e675027d31727ce33cdb29eab32d025bdc9/ruff-0.12.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ca4c3a7f937725fd2413c0e884b5248a19369ab9bdd850b5781348ba283f644", size = 13536288, upload-time = "2025-08-28T13:58:40.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/30/d5496fa09aba59b5e01ea76775a4c8897b13055884f56f1c35a4194c2297/ruff-0.12.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4d1df0098124006f6a66ecf3581a7f7e754c4df7644b2e6704cd7ca80ff95211", size = 14490633, upload-time = "2025-08-28T13:58:42.285Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2f/81f998180ad53445d403c386549d6946d0748e536d58fce5b5e173511183/ruff-0.12.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a8dd5f230efc99a24ace3b77e3555d3fbc0343aeed3fc84c8d89e75ab2ff793", size = 13888430, upload-time = "2025-08-28T13:58:44.641Z" },
+    { url = "https://files.pythonhosted.org/packages/87/71/23a0d1d5892a377478c61dbbcffe82a3476b050f38b5162171942a029ef3/ruff-0.12.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4dc75533039d0ed04cd33fb8ca9ac9620b99672fe7ff1533b6402206901c34ee", size = 12913133, upload-time = "2025-08-28T13:58:47.039Z" },
+    { url = "https://files.pythonhosted.org/packages/80/22/3c6cef96627f89b344c933781ed38329bfb87737aa438f15da95907cbfd5/ruff-0.12.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fc58f9266d62c6eccc75261a665f26b4ef64840887fc6cbc552ce5b29f96cc8", size = 13169082, upload-time = "2025-08-28T13:58:49.157Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b5/68b3ff96160d8b49e8dd10785ff3186be18fd650d356036a3770386e6c7f/ruff-0.12.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5a0113bd6eafd545146440225fe60b4e9489f59eb5f5f107acd715ba5f0b3d2f", size = 13139490, upload-time = "2025-08-28T13:58:51.593Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b9/050a3278ecd558f74f7ee016fbdf10591d50119df8d5f5da45a22c6afafc/ruff-0.12.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0d737b4059d66295c3ea5720e6efc152623bb83fde5444209b69cd33a53e2000", size = 11958928, upload-time = "2025-08-28T13:58:53.943Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bc/93be37347db854806904a43b0493af8d6873472dfb4b4b8cbb27786eb651/ruff-0.12.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:916fc5defee32dbc1fc1650b576a8fed68f5e8256e2180d4d9855aea43d6aab2", size = 11764513, upload-time = "2025-08-28T13:58:55.976Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a1/1471751e2015a81fd8e166cd311456c11df74c7e8769d4aabfbc7584c7ac/ruff-0.12.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c984f07d7adb42d3ded5be894fb4007f30f82c87559438b4879fe7aa08c62b39", size = 12745154, upload-time = "2025-08-28T13:58:58.16Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/2542b14890d0f4872dd81b7b2a6aed3ac1786fae1ce9b17e11e6df9e31e3/ruff-0.12.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e07fbb89f2e9249f219d88331c833860489b49cdf4b032b8e4432e9b13e8a4b9", size = 13227653, upload-time = "2025-08-28T13:59:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/2fbfc61047dbfd009c58a28369a693a1484ad15441723be1cd7fe69bb679/ruff-0.12.11-py3-none-win32.whl", hash = "sha256:c792e8f597c9c756e9bcd4d87cf407a00b60af77078c96f7b6366ea2ce9ba9d3", size = 11944270, upload-time = "2025-08-28T13:59:02.347Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/34276984705bfe069cd383101c45077ee029c3fe3b28225bf67aa35f0647/ruff-0.12.11-py3-none-win_amd64.whl", hash = "sha256:a3283325960307915b6deb3576b96919ee89432ebd9c48771ca12ee8afe4a0fd", size = 13046600, upload-time = "2025-08-28T13:59:04.751Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a8/001d4a7c2b37623a3fd7463208267fb906df40ff31db496157549cfd6e72/ruff-0.12.11-py3-none-win_arm64.whl", hash = "sha256:bae4d6e6a2676f8fb0f98b74594a048bae1b944aab17e9f5d504062303c6dbea", size = 12135290, upload-time = "2025-08-28T13:59:06.933Z" },
 ]
 
 [[package]]
@@ -452,53 +465,20 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.32.0.20241016"
+version = "2.32.0.20240914"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
 dependencies = [
-    { name = "urllib3", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/3c/4f2a430c01a22abd49a583b6b944173e39e7d01b688190a5618bd59a2e22/types-requests-2.32.0.20241016.tar.gz", hash = "sha256:0d9cad2f27515d0e3e3da7134a1b6f28fb97129d86b867f24d9c726452634d95", size = 18065, upload-time = "2024-10-16T02:46:10.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/9e/aea33405c230cc3984c9f1065012d3a2003cef910730c367a0e91e7a4901/types-requests-2.32.0.20240914.tar.gz", hash = "sha256:2850e178db3919d9bf809e434eef65ba49d0e7e33ac92d588f4a5e295fffd405", size = 18030, upload-time = "2024-09-14T02:36:52.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/01/485b3026ff90e5190b5e24f1711522e06c79f4a56c8f4b95848ac072e20f/types_requests-2.32.0.20241016-py3-none-any.whl", hash = "sha256:4195d62d6d3e043a4eaaf08ff8a62184584d2e8684e9d2aa178c7915a7da3747", size = 15836, upload-time = "2024-10-16T02:46:09.734Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.32.4.20250913"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.9'",
-]
-dependencies = [
-    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/27/489922f4505975b11de2b5ad07b4fe1dca0bca9be81a703f26c5f3acfce5/types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d", size = 23113, upload-time = "2025-09-13T02:40:02.309Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1", size = 20658, upload-time = "2025-09-13T02:40:01.115Z" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.13.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/55/ea44dad71b9d92f86198f7448f5ba46ac919355f4f69bb1c0fa1af02b1b4/types_requests-2.32.0.20240914-py3-none-any.whl", hash = "sha256:59c2f673eb55f32a99b2894faf6020e1a9f4a402ad0f192bfee0b64469054310", size = 15838, upload-time = "2024-09-14T02:36:50.645Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.9'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
@@ -506,24 +486,24 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
-]
-
-[[package]]
-name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.9'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
 ]


### PR DESCRIPTION
# Feat: Secrets handling for multiple platforms

This PR introduces robust, pluggable secrets management and modernizes linting/typing CI.

## Summary
- Add `secrets_resolver.py` with support for:
  - `env:NAME` / `${NAME}`
  - `file:/path`
  - `op://vault/item/field` (1Password CLI)
  - `aws-sm://[region/]secret_id[#json_key]` (AWS Secrets Manager via AWS CLI)
  - `vault://path[#field]` (HashiCorp Vault KV via `vault` CLI)
  - `sops://path[#json.key]` (Mozilla SOPS CLI; JSON)
- Orchestrator now passes secrets via environment only (no CLI exposure) and resolves refs from `sensors.toml`.
- Scripts accept env fallbacks and resolve refs when provided directly.
- Elasticsearch creds support secret refs for `ES_PASSWORD` / `ES_API_KEY`.
- Docs updated: examples, secrets usage, local checks, pre-commit, CI badge.
- Add GitHub Actions CI: ruff + mypy on push/PR.
- Add pre-commit hooks for ruff and mypy.
- Pin dev deps for consistent tooling (`ruff`, `mypy`, `types-requests`, `pre-commit`).
- Bump minimum Python to 3.9 to satisfy tooling requirements.

## Files of Note
- `secrets_resolver.py` (new)
- `orchestrate_sensors.py` (env-only secrets)
- `process_cowrie.py`, `refresh_cache_and_reports.py`, `submit_vtfiles.py`, `cowrie_malware_enrichment.py` (env + ref resolution)
- `es_reports.py` (ES secret ref support)
- `sensors.example.toml` (secret ref examples)
- `.github/workflows/ci.yml` (CI)
- `.pre-commit-config.yaml` (hooks)
- `pyproject.toml` (pinned dev-deps, Python >=3.9)
- `README.md` (docs)

## Rationale
- Keep secrets out of CLI args and process lists.
- Allow any student to use their preferred secrets manager.
- Ensure consistent linting/typing gate pre-commit and in CI.

## Notes
- Secret CLIs (op/aws/vault/sops) must be authenticated/configured on the host; no login flows are added.
- SOPS extraction expects JSON when using `#key` fragments.
- No behavioral changes when env/flags are not used (backwards compatible with plain values).

## Testing
- `pre-commit run --all-files`: ruff + mypy pass.
- `ruff check .` and `mypy .` also pass in CI.

