### PR TITLE
✨ Add status updates for process phase transitions

### DIFF
--- a/process_cowrie.py
+++ b/process_cowrie.py
@@ -2126,10 +2126,16 @@ for filename in list_of_files:
     processed_files += 1
     write_status(state='reading', total_files=total_files, processed_files=processed_files, current_file=filename)
 
+# File processing complete - update status
+write_status(state='files_complete', total_files=total_files, processed_files=processed_files, current_file='')
+
 vt_session = requests.session()
 dshield_session = requests.session()
 uh_session = requests.session()
 spur_session = requests.session()
+
+# Report generation starting - update status
+write_status(state='generating_reports', total_files=total_files, processed_files=processed_files, current_file='')
 
 if summarizedays:
     session_id = get_session_id(data, "all", "unnecessary")
@@ -2307,3 +2313,6 @@ else:
 
 print(summarystring)
 db_commit()
+
+# Process complete - final status update
+write_status(state='complete', total_files=total_files, processed_files=processed_files, current_file='')


### PR DESCRIPTION
## Problem

When processing files in time windows (e.g., 90 days at file 89 or 7 days at file 6), the status would keep repeating the same 'reading' state until reports were completed, providing no indication that file processing was actually done.

## Solution

Added clear status updates at key process transition points to provide better visibility into what phase the process is currently in.

## Changes Made

### New Status States
- **files_complete** - Indicates file processing window is finished
- **generating_reports** - Shows report generation has started  
- **complete** - Final status when entire process is done

### Status Flow


### Implementation Details
- Added status update after file processing loop completes
- Added status update when report generation begins
- Added final status update when process finishes
- Clears current_file field for non-reading phases

## Benefits

- ✅ **Eliminates repetitive status** - No more stuck 'reading' state
- ✅ **Clear phase visibility** - Users know exactly what's happening
- ✅ **Better UX** - Professional status progression
- ✅ **Debugging aid** - Easier to identify where process might be stuck

## Testing

- [x] Code passes linting (ruff, mypy)
- [x] Syntax validation successful
- [x] No functional changes to core processing logic
- [x] Status updates are non-blocking

## Type of Change

- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Screenshots/Examples

**Before:** Status stuck on 'reading' with last file name
**After:** Clear progression through process phases

Resolves the repetitive status issue reported during testing.