### PR TITLE
🐛 Fix misleading file count in status display when using --days parameter

### DIFF
--- a/process_cowrie.py
+++ b/process_cowrie.py
@@ -424,6 +424,19 @@ list_of_files = []
 for each_file in path_entries:
     if ".json" in each_file.name:
         list_of_files.append(each_file.name)
+
+# Apply day filtering before setting total_files count
+if summarizedays:
+    days = int(summarizedays)
+    print("Days to summarize: " + str(days))
+    file_list = []
+    i = 0
+    while len(list_of_files) > 0 and (i < days):
+        if i < days:
+            file_list.append(list_of_files.pop())
+        i += 1
+    list_of_files = file_list
+
 total_files = len(list_of_files)
 processed_files = 0
 write_status(state='starting', total_files=total_files, processed_files=processed_files)
@@ -1995,17 +2008,6 @@ initialize_database()
 
 if len(list_of_files) == 0:
     sys.exit(0)
-
-if summarizedays:
-    days = int(summarizedays)
-    print("Days to summarize: " + str(days))
-    file_list = []
-    i = 0
-    while len(list_of_files) > 0 and (i < days):
-        if i < days:
-            file_list.append(list_of_files.pop())
-        i += 1
-    list_of_files = file_list
 
 
 def open_json_lines(path: str):


### PR DESCRIPTION
## Problem

When using the `--days` parameter (e.g., `--days 7`), the status display shows misleading file counts like `generating_reports 7/333` instead of the correct `generating_reports 7/7`. This happens because:

1. All files in the directory (333) are discovered first
2. `total_files` count is set to 333 before filtering
3. Day filtering happens later, reducing the actual files to process
4. Status shows the original total (333) instead of the filtered count (7)

## Solution

Moved the day filtering logic to happen immediately after file discovery and before setting the `total_files` count. This ensures the status display accurately reflects the number of files that will actually be processed.

## Changes Made

### File Filtering Logic
- **Moved filtering** from after database initialization to immediately after file discovery
- **Removed duplicate filtering** that was happening later in the code
- **Set `total_files`** after filtering is complete, not before

### Code Flow
**Before:**
```
1. Discover all files (333)
2. Set total_files = 333
3. Initialize database
4. Filter files (reduce to 7)
5. Process files (status shows 7/333)
```

**After:**
```
1. Discover all files (333)
2. Filter files (reduce to 7)
3. Set total_files = 7
4. Initialize database
5. Process files (status shows 7/7)
```

## Benefits

- ✅ **Accurate status display** - Shows correct file counts (7/7 instead of 7/333)
- ✅ **Better user experience** - No confusion about how many files are being processed
- ✅ **Consistent behavior** - Status always reflects actual work being done
- ✅ **No functional changes** - Same files are processed, just better status reporting

## Testing

- [x] Code passes linting (ruff, mypy)
- [x] Syntax validation successful
- [x] No changes to core processing logic
- [x] File filtering logic preserved exactly

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Examples

**Before:**
```
[status] reading 5/333 cowrie.json.2025-09-11.bz2
[status] generating_reports 7/333
```

**After:**
```
[status] reading 5/7 cowrie.json.2025-09-11.bz2
[status] generating_reports 7/7
```

Fixes the misleading file count display when using `--days` parameter.
