### PR TITLE
fix(docs): resolve Read the Docs build configuration error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,26 +13,16 @@ formats:
   - pdf
   - epub
 
-# Python configuration
-python:
-  version: "3.13"
-  install:
-    - method: pip
-      path: .
-    - requirements: docs/sphinx/requirements.txt
-
 # Build configuration
 build:
   os: ubuntu-22.04
   tools:
     python: "3.13"
   jobs:
-    pre_build:
-      # Install system dependencies if needed
-      - echo "Installing system dependencies..."
     post_checkout:
+      # Install project dependencies
+      - pip install -e .
+      # Install Sphinx and documentation requirements
+      - pip install -r docs/sphinx/requirements.txt
       # Ensure submodules are checked out if any
       - git submodule update --init --recursive
-    post_install:
-      # Verify Sphinx installation
-      - python -m sphinx --version


### PR DESCRIPTION
- Remove invalid 'python.version' configuration key
- Move dependency installation to post_checkout hook
- Ensure proper Python 3.13 setup for Sphinx builds
- Install project and documentation dependencies before build

Fixes build error: 'Invalid configuration key: python.version'
Refs: Read the Docs v2 configuration specification